### PR TITLE
OWNERS: update per repo migration issue

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,3 @@
 approvers:
-  - pmotyka
-  - maxdrib
-  - vignesh-goutham
-  - jweite-amazon
-  - mrog
-  - rejoshed
-  - wongni
+  - rohityadavcloud
+  - davidjumani


### PR DESCRIPTION
Refer to https://github.com/kubernetes/org/issues/3279, to facilitate repo migration we can start with a limited set of owners that we can grow over time post-migration. I've raised this issue with the org https://github.com/kubernetes/org/issues/3312