### PR TITLE
Add moving the cluster to the workload cluster to make the cluster a management cluster

### DIFF
--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// SelfHostedSpecInput is the input for SelfHostedSpec.
+type SelfHostedSpecInput struct {
+	E2EConfig             *clusterctl.E2EConfig
+	ClusterctlConfigPath  string
+	BootstrapClusterProxy framework.ClusterProxy
+	ArtifactFolder        string
+	SkipCleanup           bool
+	Flavor                string
+}
+
+// SelfHostedSpec implements a test that verifies Cluster API creating a cluster, pivoting to a self-hosted cluster.
+// NOTE: This test works with Clusters with and without ClusterClass.
+func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput) {
+	var (
+		specName         = "self-hosted"
+		input            SelfHostedSpecInput
+		namespace        *corev1.Namespace
+		cancelWatches    context.CancelFunc
+		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+
+		selfHostedClusterProxy  framework.ClusterProxy
+		selfHostedNamespace     *corev1.Namespace
+		selfHostedCancelWatches context.CancelFunc
+		selfHostedCluster       *clusterv1.Cluster
+	)
+
+	BeforeEach(func() {
+		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
+		input = inputGetter()
+		Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
+		Expect(input.ClusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. input.ClusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersion))
+
+		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+	})
+
+	It("Should pivot the bootstrap cluster to a self-hosted cluster", func() {
+		By("Creating a workload cluster")
+
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy:    input.BootstrapClusterProxy,
+			CNIManifestPath: input.E2EConfig.GetVariable(CNIPath),
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     input.ClusterctlConfigPath,
+				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				Flavor:                   input.Flavor,
+				Namespace:                namespace.Name,
+				ClusterName:              fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
+				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),
+				ControlPlaneMachineCount: pointer.Int64Ptr(1),
+				WorkerMachineCount:       pointer.Int64Ptr(1),
+			},
+			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		}, clusterResources)
+
+		Byf("Turning the workload cluster into a management cluster")
+		cluster := clusterResources.Cluster
+		// Get a ClusterBroker so we can interact with the workload cluster
+		selfHostedClusterProxy = input.BootstrapClusterProxy.GetWorkloadCluster(ctx, cluster.Namespace, cluster.Name)
+
+		Byf("Creating a namespace for hosting the %s test spec", specName)
+		selfHostedNamespace, selfHostedCancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
+			Creator:   selfHostedClusterProxy.GetClient(),
+			ClientSet: selfHostedClusterProxy.GetClientSet(),
+			Name:      namespace.Name,
+			LogFolder: filepath.Join(input.ArtifactFolder, "clusters", "bootstrap"),
+		})
+
+		Byf("Initializing the workload cluster (kubeconfig path: %s)", selfHostedClusterProxy.GetKubeconfigPath())
+		clusterctl.InitManagementClusterAndWatchControllerLogs(ctx, clusterctl.InitManagementClusterAndWatchControllerLogsInput{
+			ClusterProxy:            selfHostedClusterProxy,
+			ClusterctlConfigPath:    input.ClusterctlConfigPath,
+			InfrastructureProviders: input.E2EConfig.InfrastructureProviders(),
+			LogFolder:               filepath.Join(input.ArtifactFolder, "clusters", cluster.Name),
+		}, input.E2EConfig.GetIntervals(specName, "wait-controllers")...)
+
+		By("Ensure API servers are stable before doing move")
+		// Nb. This check was introduced to prevent doing move to self-hosted in an aggressive way and thus avoid flakes.
+		// More specifically, we were observing the test failing to get objects from the API server during move, so we
+		// are now testing the API servers are stable before starting move.
+		Consistently(func() error {
+			kubeSystem := &corev1.Namespace{}
+			return input.BootstrapClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
+		}, "5s", "100ms").Should(BeNil(), "Failed to assert bootstrap API server stability")
+		Consistently(func() error {
+			kubeSystem := &corev1.Namespace{}
+			return selfHostedClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
+		}, "5s", "100ms").Should(BeNil(), "Failed to assert self-hosted API server stability")
+
+		By("Moving the cluster to self hosted")
+		clusterctl.Move(ctx, clusterctl.MoveInput{
+			LogFolder:            filepath.Join(input.ArtifactFolder, "clusters", "bootstrap"),
+			ClusterctlConfigPath: input.ClusterctlConfigPath,
+			FromKubeconfigPath:   input.BootstrapClusterProxy.GetKubeconfigPath(),
+			ToKubeconfigPath:     selfHostedClusterProxy.GetKubeconfigPath(),
+			Namespace:            namespace.Name,
+		})
+
+		By("Waiting for the cluster to be reconciled after moving to self hosted")
+		selfHostedCluster = framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{
+			Getter:    selfHostedClusterProxy.GetClient(),
+			Namespace: selfHostedNamespace.Name,
+			Name:      cluster.Name,
+		}, input.E2EConfig.GetIntervals(specName, "wait-cluster")...)
+
+		controlPlane := framework.GetKubeadmControlPlaneByCluster(ctx, framework.GetKubeadmControlPlaneByClusterInput{
+			Lister:      selfHostedClusterProxy.GetClient(),
+			ClusterName: selfHostedCluster.Name,
+			Namespace:   selfHostedCluster.Namespace,
+		})
+		Expect(controlPlane).ToNot(BeNil())
+
+		By("PASSED!")
+	})
+
+	AfterEach(func() {
+		if selfHostedNamespace != nil {
+			// Dump all Cluster API related resources to artifacts before pivoting back.
+			framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
+				Lister:    selfHostedClusterProxy.GetClient(),
+				Namespace: namespace.Name,
+				LogPath:   filepath.Join(input.ArtifactFolder, "clusters", clusterResources.Cluster.Name, "resources"),
+			})
+		}
+		if selfHostedCluster != nil {
+			By("Ensure API servers are stable before doing move")
+			// Nb. This check was introduced to prevent doing move back to bootstrap in an aggressive way and thus avoid flakes.
+			// More specifically, we were observing the test failing to get objects from the API server during move, so we
+			// are now testing the API servers are stable before starting move.
+			Consistently(func() error {
+				kubeSystem := &corev1.Namespace{}
+				return input.BootstrapClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
+			}, "5s", "100ms").Should(BeNil(), "Failed to assert bootstrap API server stability")
+			Consistently(func() error {
+				kubeSystem := &corev1.Namespace{}
+				return selfHostedClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
+			}, "5s", "100ms").Should(BeNil(), "Failed to assert self-hosted API server stability")
+
+			By("Moving the cluster back to bootstrap")
+			clusterctl.Move(ctx, clusterctl.MoveInput{
+				LogFolder:            filepath.Join(input.ArtifactFolder, "clusters", clusterResources.Cluster.Name),
+				ClusterctlConfigPath: input.ClusterctlConfigPath,
+				FromKubeconfigPath:   selfHostedClusterProxy.GetKubeconfigPath(),
+				ToKubeconfigPath:     input.BootstrapClusterProxy.GetKubeconfigPath(),
+				Namespace:            selfHostedNamespace.Name,
+			})
+
+			By("Waiting for the cluster to be reconciled after moving back to booststrap")
+			clusterResources.Cluster = framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{
+				Getter:    input.BootstrapClusterProxy.GetClient(),
+				Namespace: namespace.Name,
+				Name:      clusterResources.Cluster.Name,
+			}, input.E2EConfig.GetIntervals(specName, "wait-cluster")...)
+		}
+		if selfHostedCancelWatches != nil {
+			selfHostedCancelWatches()
+		}
+
+		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
+		dumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, namespace, cancelWatches, clusterResources.Cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
+	})
+}

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -1,0 +1,36 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("When testing Cluster API working on self-hosted clusters", func() {
+	SelfHostedSpec(ctx, func() SelfHostedSpecInput {
+		return SelfHostedSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+		}
+	})
+})


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

Adding an e2e test case that turning a workload cluster to a management cluster. 
Note that this test doesn't work with the current capc controller image building and pushing because we uses a local repository for storing the image, however, the image in the local repository is not accessible from the workload cluster. To run this test we need to push to a remote repository so that the image is reachable from both the bootstrap and the workload clusters. 

```
IMG=public.ecr.aws/r9t0b9f2/cluster-api-provider-capc:e2e-20220502a make docker-build docker-push
JOB=self-hosted make IMG_LOCAL=public.ecr.aws/r9t0b9f2/cluster-api-provider-capc:e2e-20220502a run-e2e
```

*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->