### PR TITLE
Fix intermittent e2e deploy test failures where empty string returned as the test html

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -187,9 +188,22 @@ func DeployAppToWorkloadClusterAndWaitForDeploymentReady(ctx context.Context, wo
 
 func DownloadFromAppInWorkloadCluster(ctx context.Context, workloadKubeconfigPath string, appName string, port int, path string) (string, error) {
 	runArgs := []string{
-		"-i", "--restart=Never", "dummy", "--image=dockerqa/curl:ubuntu-trusty", "--command", "--", "curl", "--silent", fmt.Sprintf("%s:%d%s", appName, port, path),
+		// Required by below: container name is runArg zero.
+		"dummy", "-i", "--restart=Never", "--image=dockerqa/curl:ubuntu-trusty", "--command", "--", "curl", "--silent", "--show-error", fmt.Sprintf("%s:%d%s", appName, port, path),
 	}
-	return KubectlExec(ctx, "run", workloadKubeconfigPath, runArgs...)
+	var result, err = KubectlExec(ctx, "run", workloadKubeconfigPath, runArgs...)
+	if err != nil {
+		return result, err
+	}
+	if result == "" {
+		// A single retry to accommodate occasional cases where an empty string is returned, ostensibly
+		//  because the service isn't fully ready.  Subsequent requests have always worked.
+		fmt.Println("Retrying html download")
+		time.Sleep(5 * time.Second)
+		runArgs[0] = "dummy2" // Assumed: container name is runArg zero.
+		result, err = KubectlExec(ctx, "run", workloadKubeconfigPath, runArgs...)
+	}
+	return result, err
 }
 
 type cloudConfig struct {


### PR DESCRIPTION
All clusters exhibiting this failure only do so for the first request made to the test httpd service.  Readiness probes did not help.

*Issue #, if available:*

*Description of changes:*
Added a delayed retry of the html fetch.

*Testing performed:*
Re-ran test until the problem occurred and was reported.  Observed that the delayed retry succeeded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->