### PR TITLE
Fixup for Zones Panic

### DIFF
--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -148,6 +148,9 @@ func (r *CloudStackMachineReconciliationRunner) SetFailureDomainOnCSMachine() (r
 				return ctrl.Result{}, errors.Errorf("could not find zone by zoneName: %s", r.ReconciliationSubject.Spec.ZoneName)
 			}
 		} else { // No Zone Specified, pick a Random Zone.
+			if len(r.Zones.Items) < 1 { // Double check that zones are present.
+				return r.RequeueWithMessage("no zones found, requeueing")
+			}
 			randNum := (rand.Int() % len(r.Zones.Items)) // #nosec G404 -- weak crypt rand doesn't matter here.
 			r.ReconciliationSubject.Status.ZoneID = r.Zones.Items[randNum].Spec.ID
 		}

--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -148,6 +148,7 @@ func (r *CloudStackMachineReconciliationRunner) SetFailureDomainOnCSMachine() (r
 				return ctrl.Result{}, errors.Errorf("could not find zone by zoneName: %s", r.ReconciliationSubject.Spec.ZoneName)
 			}
 		} else { // No Zone Specified, pick a Random Zone.
+			// TODO: Add an additional controller test for this once controller test upgrades are merged.
 			if len(r.Zones.Items) < 1 { // Double check that zones are present.
 				return r.RequeueWithMessage("no zones found, requeueing")
 			}

--- a/controllers/utils/zones.go
+++ b/controllers/utils/zones.go
@@ -75,6 +75,8 @@ func (r *ReconciliationRunner) GetZones(zones *infrav1.CloudStackZoneList) Cloud
 			client.MatchingLabels(capiClusterLabel),
 		); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed to list zones")
+		} else if len(zones.Items) < 1 {
+			return r.RequeueWithMessage("no zones found, requeueing")
 		}
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
*Issue #, if available:* CTECH-265

*Description of changes:*
Adds a check for the presence of zones prior to modding on the length of their array. Also requeues reconciliation if zones are not found.

*Testing performed:*
TBD.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->