### PR TITLE
GetZonesAndRequeueIfMissing method added to fix affinity group deletion

### DIFF
--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -90,7 +90,7 @@ func (reconciler *CloudStackMachineReconciler) Reconcile(ctx context.Context, re
 
 func (r *CloudStackMachineReconciliationRunner) Reconcile() (retRes ctrl.Result, reterr error) {
 	return r.RunReconciliationStages(
-		r.GetZones(r.Zones),
+		r.GetZonesAndRequeueIfMissing(r.Zones),
 		r.GetParent(r.ReconciliationSubject, r.CAPIMachine),
 		r.RequeueIfCloudStackClusterNotReady,
 		r.ConsiderAffinity,

--- a/controllers/utils/zones.go
+++ b/controllers/utils/zones.go
@@ -75,8 +75,6 @@ func (r *ReconciliationRunner) GetZones(zones *infrav1.CloudStackZoneList) Cloud
 			client.MatchingLabels(capiClusterLabel),
 		); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed to list zones")
-		} else if len(zones.Items) < 1 {
-			return r.RequeueWithMessage("no zones found, requeueing")
 		}
 		return ctrl.Result{}, nil
 	}

--- a/controllers/utils/zones.go
+++ b/controllers/utils/zones.go
@@ -63,7 +63,7 @@ func (r *ReconciliationRunner) CreateZones(zoneSpecs []infrav1.Zone) CloudStackR
 	}
 }
 
-// GetZones gets CloudStackZones owned by a CloudStackCluster via an ownership label.
+// GetZones gets CloudStackZones owned by a CloudStackCluster.
 func (r *ReconciliationRunner) GetZones(zones *infrav1.CloudStackZoneList) CloudStackReconcilerMethod {
 	return func() (ctrl.Result, error) {
 		capiClusterLabel := map[string]string{
@@ -80,8 +80,7 @@ func (r *ReconciliationRunner) GetZones(zones *infrav1.CloudStackZoneList) Cloud
 	}
 }
 
-// GetZonesAndRequeueIfMissing gets CloudStackZones owned by a CloudStackCluster via an ownership label, and requeues
-// if none are found.
+// GetZonesAndRequeueIfMissing gets CloudStackZones owned by a CloudStackCluster and requeues if none are found.
 func (r *ReconciliationRunner) GetZonesAndRequeueIfMissing(zones *infrav1.CloudStackZoneList) CloudStackReconcilerMethod {
 	return func() (ctrl.Result, error) {
 		if res, err := r.GetZones(zones)(); r.ShouldReturn(res, err) {

--- a/controllers/utils/zones.go
+++ b/controllers/utils/zones.go
@@ -81,3 +81,16 @@ func (r *ReconciliationRunner) GetZones(zones *infrav1.CloudStackZoneList) Cloud
 		return ctrl.Result{}, nil
 	}
 }
+
+// GetZonesAndRequeueIfMissing gets CloudStackZones owned by a CloudStackCluster via an ownership label, and requeues
+// if none are found.
+func (r *ReconciliationRunner) GetZonesAndRequeueIfMissing(zones *infrav1.CloudStackZoneList) CloudStackReconcilerMethod {
+	return func() (ctrl.Result, error) {
+		if res, err := r.GetZones(zones)(); r.ShouldReturn(res, err) {
+			return res, err
+		} else if len(zones.Items) < 1 {
+			return r.RequeueWithMessage("no zones found, requeueing")
+		}
+		return ctrl.Result{}, nil
+	}
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Separates the requeueing if Zones missing into a method of its own to prevent the conflation of GetZones with a check for zones. Without this affinity groups cannot be deleted as affinity groups calls GetZones.

*Testing performed:*
![image](https://user-images.githubusercontent.com/93345136/175996896-cde67618-cc81-4c64-bf0f-14cd63771eb7.png)

E2E PR-Blocking

Soon more.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->