### PR TITLE
Remove stopping machine from DestroyOneMachine 

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -220,12 +220,6 @@ func DestroyOneMachine(clusterName string, machineType string) {
 	}
 
 	Byf("Destroying machine %s", vmToDestroy.Name)
-	stopParams := client.VirtualMachine.NewStopVirtualMachineParams(vmToDestroy.Id)
-	stopParams.SetForced(true)
-	_, err = client.VirtualMachine.StopVirtualMachine(stopParams)
-	if err != nil {
-		Fail("Failed to stop machine: " + err.Error())
-	}
 	destroyParams := client.VirtualMachine.NewDestroyVirtualMachineParams(vmToDestroy.Id)
 	destroyParams.SetExpunge(true)
 	_, err = client.VirtualMachine.DestroyVirtualMachine(destroyParams)


### PR DESCRIPTION
*Issue #, if available:*
Machine remediation e2e test fails with an error `Failed to destroy machine: Undefined error: {"errorcode":530,"errortext":"Unable to destroy VM[User|i-2-86650-VM]"}`

*Description of changes:*
Remove stopping machine from DestroyOneMachine to avoid an error in DestroyVirtualMachine because CAPC destroys the stopped machine
            
*Testing performed:*
The failing test is now passing. 

```
Ran 1 of 23 Specs in 1557.310 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 22 Skipped
PASS
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->