### PR TITLE
Added alternative release-manifest with kube-rbac-proxy for exposing the metrics port.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,16 @@ config/.flag.mk: bin/controller-gen $(MANIFEST_GEN_INPUTS)
 .PHONY: release-manifests
 RELEASE_MANIFEST_TARGETS=$(RELEASE_DIR)/infrastructure-components.yaml $(RELEASE_DIR)/metadata.yaml
 RELEASE_MANIFEST_INPUTS=bin/kustomize config/.flag.mk $(shell find config)
+RELEASE_MANIFEST_SOURCE_BASE ?= config/default
 release-manifests: $(RELEASE_MANIFEST_TARGETS) ## Create kustomized release manifest in $RELEASE_DIR (defaults to out).
 $(RELEASE_DIR)/%: $(RELEASE_MANIFEST_INPUTS)
 	@mkdir -p $(RELEASE_DIR)
 	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
-	kustomize build config/default > $(RELEASE_DIR)/infrastructure-components.yaml
+	kustomize build $(RELEASE_MANIFEST_SOURCE_BASE) > $(RELEASE_DIR)/infrastructure-components.yaml
+
+.PHONY: release-manifests-metrics-port
+RELEASE_MANIFEST_SOURCE_BASE = config/default-with-metrics-port
+release-manifests-metrics-port: release-manifests
 
 DEEPCOPY_GEN_TARGETS=$(shell find api -type d -name "v*" -exec echo {}\/zz_generated.deepcopy.go \;)
 DEEPCOPY_GEN_INPUTS=$(shell find ./api -name "*test*" -prune -o -name "*zz_generated*" -prune -o -type f -print)

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ $(RELEASE_DIR)/%: $(RELEASE_MANIFEST_INPUTS)
 	kustomize build $(RELEASE_MANIFEST_SOURCE_BASE) > $(RELEASE_DIR)/infrastructure-components.yaml
 
 .PHONY: release-manifests-metrics-port
-RELEASE_MANIFEST_SOURCE_BASE = config/default-with-metrics-port
-release-manifests-metrics-port: release-manifests
+release-manifests-metrics-port:
+	make release-manifests RELEASE_MANIFEST_SOURCE_BASE=config/default-with-metrics-port
 
 DEEPCOPY_GEN_TARGETS=$(shell find api -type d -name "v*" -exec echo {}\/zz_generated.deepcopy.go \;)
 DEEPCOPY_GEN_INPUTS=$(shell find ./api -name "*test*" -prune -o -name "*zz_generated*" -prune -o -type f -print)

--- a/config/default-with-metrics-port/auth_proxy_client_clusterrole.yaml
+++ b/config/default-with-metrics-port/auth_proxy_client_clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/config/default-with-metrics-port/auth_proxy_role.yaml
+++ b/config/default-with-metrics-port/auth_proxy_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/config/default-with-metrics-port/auth_proxy_role_binding.yaml
+++ b/config/default-with-metrics-port/auth_proxy_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxy-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/default-with-metrics-port/auth_proxy_service.yaml
+++ b/config/default-with-metrics-port/auth_proxy_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: capc-controller-manager

--- a/config/default-with-metrics-port/kustomization.yaml
+++ b/config/default-with-metrics-port/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../default
+
+resources:
+- auth_proxy_client_clusterrole.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml
+- auth_proxy_service.yaml
+
+patchesStrategicMerge:
+  - manager_auth_proxy_patch.yaml

--- a/config/default-with-metrics-port/manager_auth_proxy_patch.yaml
+++ b/config/default-with-metrics-port/manager_auth_proxy_patch.yaml
@@ -1,0 +1,22 @@
+# This patch inject a sidecar container which is a HTTP proxy for the
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https


### PR DESCRIPTION
Also added supporting clusterroles, clusterrolebinding, service and make target to build this alternate release-manifest.

*Issue #, if available:*

*Description of changes:*
Additions to *config/* directory tree, in new *default-with-metrics-port* directory.
New make target *release-manifests-metrics-port*

*Testing performed:*
Successfully queried metrics port through the proxy from a pod in capc-system with default service account token and ca.crt, supported by clusterrolebinding of capc-system default service account to capc-system-metrics-reader clusterrole. 
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->