### PR TITLE
e2e: Add test for invalid ip as control plane endpoint

### DIFF
--- a/test/e2e/config/cloudstack.yaml
+++ b/test/e2e/config/cloudstack.yaml
@@ -94,6 +94,7 @@ providers:
       - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-disk-offering.yaml"
       - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-custom-disk-offering.yaml"
       - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-subdomain.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-ip.yaml"
       - sourcePath: "../data/shared/v1beta1/metadata.yaml"
     versions:
       - name: v1.0.0
@@ -127,6 +128,7 @@ variables:
   CLOUDSTACK_SHARED_NETWORK_NAME: Shared1
   CLUSTER_ENDPOINT_IP: 172.16.2.199
   CLUSTER_ENDPOINT_IP_2: 172.16.2.198
+  CLOUDSTACK_INVALID_IP: 1.2.3.4
   CLOUDSTACK_CONTROL_PLANE_MACHINE_OFFERING: "Large Instance"
   CLOUDSTACK_INVALID_CONTROL_PLANE_MACHINE_OFFERING: "OfferingXXXX"
   CLOUDSTACK_IMPOSSIBLE_CONTROL_PLANE_MACHINE_OFFERING: "Impossible Instance"
@@ -169,4 +171,4 @@ intervals:
   node-drain/wait-control-plane: ["15m", "10s"]
   node-drain/wait-machine-deleted: ["5m", "10s"]
 
-  
+

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-ip/cloudstack-cluster.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-ip/cloudstack-cluster.yaml
@@ -1,4 +1,4 @@
-piVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackCluster
 metadata:
   name: ${CLUSTER_NAME}

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-ip/cloudstack-cluster.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-ip/cloudstack-cluster.yaml
@@ -1,0 +1,17 @@
+piVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: CloudStackCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  failureDomains:
+  - name: ${CLOUDSTACK_FD1_NAME}
+    acsEndpoint:
+      name: ${CLOUDSTACK_FD1_SECRET_NAME}
+      namespace: default
+    zone:
+      name: ${CLOUDSTACK_ZONE_NAME}
+      network:
+        name: ${CLOUDSTACK_NETWORK_NAME}
+  controlPlaneEndpoint:
+    host: ${CLOUDSTACK_INVALID_IP}
+    port: 6443

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-ip/kustomization.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-ip/kustomization.yaml
@@ -1,0 +1,6 @@
+bases:
+  - ../bases/cluster-with-kcp.yaml
+  - ../bases/md.yaml
+
+patchesStrategicMerge:
+- ./cloudstack-cluster.yaml

--- a/test/e2e/invalid_resource.go
+++ b/test/e2e/invalid_resource.go
@@ -20,18 +20,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
-	"os"
-	"path/filepath"
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
@@ -97,6 +98,10 @@ func InvalidResourceSpec(ctx context.Context, inputGetter func() CommonSpecInput
 
 	It("Should fail due to the specified disk offer is customized but the disk size is not specified", func() {
 		testInvalidResource(ctx, input, "invalid-disk-offering-size-for-customized", "is customized, disk size can not be 0 GB")
+	})
+
+	It("Should fail due to the public IP can not be found", func() {
+		testInvalidResource(ctx, input, "invalid-public-ip", "no public addresses found in available networks")
 	})
 
 	Context("When starting with a healthy cluster", func() {

--- a/test/e2e/invalid_resource.go
+++ b/test/e2e/invalid_resource.go
@@ -101,7 +101,7 @@ func InvalidResourceSpec(ctx context.Context, inputGetter func() CommonSpecInput
 	})
 
 	It("Should fail due to the public IP can not be found", func() {
-		testInvalidResource(ctx, input, "invalid-public-ip", "no public addresses found in available networks")
+		testInvalidResource(ctx, input, "invalid-ip", "no public addresses found in available networks")
 	})
 
 	Context("When starting with a healthy cluster", func() {


### PR DESCRIPTION
*Description of changes:*

Adds an e2e test for an invalid IP as the control plane endpoint

*Testing performed:*
```
When the specified resource does not exist 
  Should fail due to the public IP can not be found
  /home/djumani/lab/capi/test/e2e/invalid_resource.go:103
STEP: Creating a namespace for hosting the "invalid-resource" test spec
INFO: Creating namespace invalid-resource-jhnl3a
INFO: Creating event watcher for namespace "invalid-resource-jhnl3a"
STEP: Configuring a cluster
INFO: clusterctl config cluster invalid-resource-0acsir --infrastructure (default) --kubernetes-version v1.23.3 --control-plane-machine-count 1 --worker-machine-count 1 --flavor invalid-public-ip
STEP: Applying...
kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/invalid-resource-0acsir-md-0 created
cluster.cluster.x-k8s.io/invalid-resource-0acsir created
machinedeployment.cluster.x-k8s.io/invalid-resource-0acsir-md-0 created
kubeadmcontrolplane.controlplane.cluster.x-k8s.io/invalid-resource-0acsir-control-plane created
cloudstackcluster.infrastructure.cluster.x-k8s.io/invalid-resource-0acsir created
cloudstackmachinetemplate.infrastructure.cluster.x-k8s.io/invalid-resource-0acsir-control-plane created
cloudstackmachinetemplate.infrastructure.cluster.x-k8s.io/invalid-resource-0acsir-md-0 created

STEP: Waiting for "no public addresses found in available networks" error to occur
STEP: Found "no public addresses found in available networks" error
STEP: PASSED!
STEP: Dumping logs from the "invalid-resource-0acsir" workload cluster
Failed to get logs for machine invalid-resource-0acsir-md-0-5f4956b6f4-hh458, cluster invalid-resource-jhnl3a/invalid-resource-0acsir: error creating container exec: Error response from daemon: No such container: invalid-resource-0acsir-md-0-5f4956b6f4-hh458
STEP: Dumping all the Cluster API resources in the "invalid-resource-jhnl3a" namespace
STEP: Deleting cluster invalid-resource-jhnl3a/invalid-resource-0acsir
STEP: Deleting cluster invalid-resource-0acsir
INFO: Waiting for the Cluster invalid-resource-jhnl3a/invalid-resource-0acsir to be deleted
STEP: Waiting for cluster invalid-resource-0acsir to be deleted
STEP: Deleting namespace used for hosting the "invalid-resource" test spec
INFO: Deleting namespace invalid-resource-jhnl3a

• [SLOW TEST:21.420 seconds]
When the specified resource does not exist
/home/djumani/lab/capi/test/e2e/invalid_resource_test.go:27
  Should fail due to the public IP can not be found
  /home/djumani/lab/capi/test/e2e/invalid_resource.go:103
------------------------------
------------------------------
STEP: Dumping logs from the bootstrap cluster
Failed to get logs for the bootstrap cluster node capi-test-control-plane: exit status 2
STEP: Tearing down the management cluster

JUnit report was created: /home/djumani/lab/capi/_artifacts/junit.e2e_suite.1.xml

Ran 1 of 1 Specs in 90.893 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->