### PR TITLE
e2e: Add kubernetes version upgrade test

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -46,18 +46,20 @@ import (
 
 // Test suite constants for e2e config variables.
 const (
-	KubernetesVersionManagement = "KUBERNETES_VERSION_MANAGEMENT"
-	KubernetesVersion           = "KUBERNETES_VERSION"
-	CNIPath                     = "CNI"
-	CNIResources                = "CNI_RESOURCES"
-	IPFamily                    = "IP_FAMILY"
-	InvalidZoneName             = "CLOUDSTACK_INVALID_ZONE_NAME"
-	InvalidDiskOfferingName     = "CLOUDSTACK_INVALID_DISK_OFFERING_NAME"
-	InvalidNetworkName          = "CLOUDSTACK_INVALID_NETWORK_NAME"
-	InvalidAccountName          = "CLOUDSTACK_INVALID_ACCOUNT_NAME"
-	InvalidDomainName           = "CLOUDSTACK_INVALID_DOMAIN_NAME"
-	InvalidTemplateName         = "CLOUDSTACK_INVALID_TEMPLATE_NAME"
-	InvalidCPOfferingName       = "CLOUDSTACK_INVALID_CONTROL_PLANE_MACHINE_OFFERING"
+	KubernetesVersionManagement  = "KUBERNETES_VERSION_MANAGEMENT"
+	KubernetesVersion            = "KUBERNETES_VERSION"
+	KubernetesVersionUpgradeFrom = "KUBERNETES_VERSION_UPGRADE_FROM"
+	KubernetesVersionUpgradeTo   = "KUBERNETES_VERSION_UPGRADE_TO"
+	CNIPath                      = "CNI"
+	CNIResources                 = "CNI_RESOURCES"
+	IPFamily                     = "IP_FAMILY"
+	InvalidZoneName              = "CLOUDSTACK_INVALID_ZONE_NAME"
+	InvalidDiskOfferingName      = "CLOUDSTACK_INVALID_DISK_OFFERING_NAME"
+	InvalidNetworkName           = "CLOUDSTACK_INVALID_NETWORK_NAME"
+	InvalidAccountName           = "CLOUDSTACK_INVALID_ACCOUNT_NAME"
+	InvalidDomainName            = "CLOUDSTACK_INVALID_DOMAIN_NAME"
+	InvalidTemplateName          = "CLOUDSTACK_INVALID_TEMPLATE_NAME"
+	InvalidCPOfferingName        = "CLOUDSTACK_INVALID_CONTROL_PLANE_MACHINE_OFFERING"
 )
 
 const (

--- a/test/e2e/config/cloudstack.yaml
+++ b/test/e2e/config/cloudstack.yaml
@@ -95,6 +95,8 @@ providers:
       - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-custom-disk-offering.yaml"
       - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-subdomain.yaml"
       - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-ip.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-before.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-after.yaml"
       - sourcePath: "../data/shared/v1beta1_provider/metadata.yaml"
     versions:
       - name: v1.0.0
@@ -107,8 +109,10 @@ providers:
             new: "--leader-elect\n        - --metrics-bind-addr=:8080"
 
 variables:
-  KUBERNETES_VERSION_MANAGEMENT: "v1.20.10"
-  KUBERNETES_VERSION: "v1.20.10"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.25.3"
+  KUBERNETES_VERSION: "v1.22.6"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.22.6"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.23.3"
   CNI: "./data/cni/kindnet.yaml"
   IP_FAMILY: "IPv4"
   NODE_DRAIN_TIMEOUT: "60s"
@@ -134,7 +138,9 @@ variables:
   CLOUDSTACK_IMPOSSIBLE_CONTROL_PLANE_MACHINE_OFFERING: "Impossible Instance"
   CLOUDSTACK_WORKER_MACHINE_OFFERING: "Medium Instance"
   CLOUDSTACK_IMPOSSIBLE_WORKER_MACHINE_OFFERING: "Impossible Instance"
-  CLOUDSTACK_TEMPLATE_NAME: kube-v1.20.10/ubuntu-2004
+  CLOUDSTACK_TEMPLATE_NAME: ubuntu-2004-kube-v1.22.6-kvm
+  CLOUDSTACK_UPGRADE_FROM_TEMPLATE_NAME: ubuntu-2004-kube-v1.22.6-kvm
+  CLOUDSTACK_UPGRADE_TO_TEMPLATE_NAME: ubuntu-2004-kube-v1.23.3-kvm
   CLOUDSTACK_INVALID_TEMPLATE_NAME: templateXXXX
   CLOUDSTACK_SSH_KEY_NAME: CAPCKeyPair6
 

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-after/cluster.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-after/cluster.yaml
@@ -1,0 +1,36 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    serviceDomain: "cluster.local"
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    kind: CloudStackCluster
+    name: ${CLUSTER_NAME}
+  controlPlaneRef:
+    kind: KubeadmControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: ${CLUSTER_NAME}-control-plane
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: CloudStackCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  failureDomains:
+  - name: ${CLOUDSTACK_FD1_NAME}
+    acsEndpoint:
+      name: ${CLOUDSTACK_FD1_SECRET_NAME}
+      namespace: default
+    zone:
+      name: ${CLOUDSTACK_ZONE_NAME}
+      network:
+        name: ${CLOUDSTACK_NETWORK_NAME}
+  controlPlaneEndpoint:
+    host: ${CLUSTER_ENDPOINT_IP}
+    port: 6443

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-after/kustomization.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-after/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+  - ./cluster.yaml
+  - ./upgrade-md.yaml
+  - ./upgrade-cp.yaml

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-after/upgrade-cp.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-after/upgrade-cp.yaml
@@ -1,0 +1,41 @@
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  kubeadmConfigSpec:
+    initConfiguration:
+      nodeRegistration:
+        name: '{{ local_hostname }}'
+        kubeletExtraArgs:
+          provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
+    clusterConfiguration:
+      imageRepository: k8s.gcr.io
+    joinConfiguration:
+      nodeRegistration:
+        name: '{{ local_hostname }}'
+        kubeletExtraArgs:
+          provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
+    preKubeadmCommands:
+      - swapoff -a
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: CloudStackMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane-upgraded
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: ${KUBERNETES_VERSION_UPGRADE_TO}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: CloudStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane-upgraded
+spec:
+  template:
+    spec:
+      offering:
+        name: ${CLOUDSTACK_CONTROL_PLANE_MACHINE_OFFERING}
+      template:
+        name: ${CLOUDSTACK_UPGRADE_TO_TEMPLATE_NAME}
+      sshKey: ${CLOUDSTACK_SSH_KEY_NAME}
+---

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-after/upgrade-md.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-after/upgrade-md.yaml
@@ -1,0 +1,51 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: ${KUBERNETES_VERSION_UPGRADE_TO}
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-md-0"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-1"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: CloudStackMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: CloudStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-1
+spec:
+  template:
+    spec:
+      offering:
+        name: ${CLOUDSTACK_WORKER_MACHINE_OFFERING}
+      template:
+        name: ${CLOUDSTACK_UPGRADE_TO_TEMPLATE_NAME}
+      sshKey: ${CLOUDSTACK_SSH_KEY_NAME}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          name: '{{ local_hostname }}'
+          kubeletExtraArgs:
+            provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
+      preKubeadmCommands:
+        - swapoff -a
+

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-before/before.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-before/before.yaml
@@ -1,0 +1,77 @@
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  kubeadmConfigSpec:
+    initConfiguration:
+      nodeRegistration:
+        name: '{{ local_hostname }}'
+        kubeletExtraArgs:
+          provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
+    clusterConfiguration:
+      imageRepository: k8s.gcr.io
+    joinConfiguration:
+      nodeRegistration:
+        name: '{{ local_hostname }}'
+        kubeletExtraArgs:
+          provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
+    preKubeadmCommands:
+      - swapoff -a
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: CloudStackMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: ${KUBERNETES_VERSION_UPGRADE_FROM}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: CloudStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      offering:
+        name: ${CLOUDSTACK_CONTROL_PLANE_MACHINE_OFFERING}
+      template:
+        name: ${CLOUDSTACK_UPGRADE_FROM_TEMPLATE_NAME}
+      sshKey: ${CLOUDSTACK_SSH_KEY_NAME}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: ${KUBERNETES_VERSION_UPGRADE_FROM}
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-md-0"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: CloudStackMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: CloudStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      offering:
+        name: ${CLOUDSTACK_WORKER_MACHINE_OFFERING}
+      template:
+        name: ${CLOUDSTACK_UPGRADE_FROM_TEMPLATE_NAME}
+      sshKey: ${CLOUDSTACK_SSH_KEY_NAME}
+

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-before/cloudstack-cluster.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-before/cloudstack-cluster.yaml
@@ -1,0 +1,17 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: CloudStackCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  failureDomains:
+  - name: ${CLOUDSTACK_FD1_NAME}
+    acsEndpoint:
+      name: ${CLOUDSTACK_FD1_SECRET_NAME}
+      namespace: default
+    zone:
+      name: ${CLOUDSTACK_ZONE_NAME}
+      network:
+        name: ${CLOUDSTACK_NETWORK_NAME}
+  controlPlaneEndpoint:
+    host: ${CLUSTER_ENDPOINT_IP}
+    port: 6443

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-before/kustomization.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-before/kustomization.yaml
@@ -1,0 +1,8 @@
+
+bases:
+  - ../bases/cluster-with-kcp.yaml
+  - ../bases/md.yaml
+
+patchesStrategicMerge:
+  - ./cloudstack-cluster.yaml
+  - ./before.yaml

--- a/test/e2e/kubernetes_version_upgrade.go
+++ b/test/e2e/kubernetes_version_upgrade.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// KubernetesVersionUpgradeSpec implements a test that verifies that MachineDeployment rolling updates are successful.
+func KubernetesVersionUpgradeSpec(ctx context.Context, inputGetter func() CommonSpecInput) {
+	var (
+		specName         = "kubernetes-version-upgrade"
+		input            CommonSpecInput
+		namespace        *corev1.Namespace
+		cancelWatches    context.CancelFunc
+		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+	)
+
+	BeforeEach(func() {
+		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
+		input = inputGetter()
+		Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
+		Expect(input.ClusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. input.ClusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersionUpgradeFrom))
+		Expect(input.E2EConfig.Variables).To(HaveValidVersion(input.E2EConfig.GetVariable(KubernetesVersionUpgradeFrom)))
+		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersionUpgradeTo))
+		Expect(input.E2EConfig.Variables).To(HaveValidVersion(input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo)))
+
+		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+	})
+
+	clusterName := fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+
+	It("Should successfully upgrade kubernetes versions when there is a change in relevant fields", func() {
+		By("Creating a workload cluster")
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy:    input.BootstrapClusterProxy,
+			CNIManifestPath: input.E2EConfig.GetVariable(CNIPath),
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     input.ClusterctlConfigPath,
+				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				Flavor:                   "kubernetes-version-upgrade-before",
+				Namespace:                namespace.Name,
+				ClusterName:              clusterName,
+				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersionUpgradeFrom),
+				ControlPlaneMachineCount: pointer.Int64Ptr(1),
+				WorkerMachineCount:       pointer.Int64Ptr(1),
+			},
+			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		}, clusterResources)
+
+		By("Upgrading to a newer Kubernetes Version")
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy:    input.BootstrapClusterProxy,
+			CNIManifestPath: input.E2EConfig.GetVariable(CNIPath),
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     input.ClusterctlConfigPath,
+				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				Flavor:                   "kubernetes-version-upgrade-after",
+				Namespace:                namespace.Name,
+				ClusterName:              clusterName,
+				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
+				ControlPlaneMachineCount: pointer.Int64Ptr(1),
+				WorkerMachineCount:       pointer.Int64Ptr(1),
+			},
+			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		}, clusterResources)
+
+		By("Waiting until nodes are ready")
+		workloadProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, namespace.Name, clusterResources.Cluster.Name)
+		workloadClient := workloadProxy.GetClient()
+		framework.WaitForNodesReady(ctx, framework.WaitForNodesReadyInput{
+			Lister:            workloadClient,
+			KubernetesVersion: input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
+			Count:             int(clusterResources.ExpectedTotalNodes()),
+			WaitForNodesReady: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+		})
+		By("Upgrade Successful")
+
+		By("PASSED!")
+	})
+
+	AfterEach(func() {
+		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
+		dumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, namespace, cancelWatches, clusterResources.Cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
+	})
+}

--- a/test/e2e/kubernetes_version_upgrade_test.go
+++ b/test/e2e/kubernetes_version_upgrade_test.go
@@ -1,0 +1,33 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("When testing Kubernetes version upgrades", func() {
+	KubernetesVersionUpgradeSpec(ctx, func() CommonSpecInput {
+		return CommonSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+		}
+	})
+})


### PR DESCRIPTION
*Description of changes:*

Adds a Kubernetes version upgrade to the e2e test suite

*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->