### PR TITLE
Update machine state checker so it doesn't delete machines when it shouldn't

### DIFF
--- a/controllers/cloudstackmachinestatechecker_controller.go
+++ b/controllers/cloudstackmachinestatechecker_controller.go
@@ -87,7 +87,7 @@ func (r *CloudStackMachineStateCheckerReconciliationRunner) Reconcile() (ctrl.Re
 
 	// capiTimeout indicates that a new VM is running, but it isn't reachable due to a network issue or a misconfiguration.
 	// When this happens, the machine should be deleted or else the cluster won't ever recover.
-	capiTimeout := csRunning && !capiRunning && csTimeInState > 1*time.Minute
+	capiTimeout := csRunning && !capiRunning && csTimeInState > 5*time.Minute
 
 	if csRunning && capiRunning {
 		r.ReconciliationSubject.Status.Ready = true

--- a/controllers/cloudstackmachinestatechecker_controller.go
+++ b/controllers/cloudstackmachinestatechecker_controller.go
@@ -82,10 +82,11 @@ func (r *CloudStackMachineStateCheckerReconciliationRunner) Reconcile() (ctrl.Re
 	csRunning := r.CSMachine.Status.InstanceState == "Running"
 	csTimeInState := r.CSMachine.Status.TimeSinceLastStateChange()
 	capiRunning := r.CAPIMachine.Status.Phase == "Running"
+	capiProvisioned := r.CAPIMachine.Status.Phase == "Provisioned"
 
 	// capiTimeout indicates that a new VM is running, but it isn't reachable due to a network issue or a misconfiguration.
 	// When this happens, the machine should be deleted or else the cluster won't ever recover.
-	capiTimeout := csRunning && !capiRunning && csTimeInState > 5*time.Minute
+	capiTimeout := csRunning && capiProvisioned && csTimeInState > 5*time.Minute
 
 	if csRunning && capiRunning {
 		r.ReconciliationSubject.Status.Ready = true


### PR DESCRIPTION
Updating machine state checker so it won't delete a machine because of the CAPI phase, unless the phase is Provisioned.  (It previously looked for any phase other than Running.)

*Issue #, if available:*

*Description of changes:*

*Testing performed:*
Manually tested with cluster creation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->