### PR TITLE
Disabling machine state checker

### DIFF
--- a/main.go
+++ b/main.go
@@ -211,10 +211,11 @@ func setupReconcilers(base utils.ReconcilerBase, mgr manager.Manager) {
 		setupLog.Error(err, "unable to create controller", "controller", "CloudStackMachine")
 		os.Exit(1)
 	}
-	if err := (&controllers.CloudStackMachineStateCheckerReconciler{ReconcilerBase: base}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "CloudStackMachineStateChecker")
-		os.Exit(1)
-	}
+	// Temporarily disabling machine state checker until we can solve the issue of machines not always being replaced.
+	//if err := (&controllers.CloudStackMachineStateCheckerReconciler{ReconcilerBase: base}).SetupWithManager(mgr); err != nil {
+	//	setupLog.Error(err, "unable to create controller", "controller", "CloudStackMachineStateChecker")
+	//	os.Exit(1)
+	//}
 	if err := (&controllers.CloudStackIsoNetReconciler{ReconcilerBase: base}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CloudStackIsoNetReconciler")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -211,11 +211,6 @@ func setupReconcilers(base utils.ReconcilerBase, mgr manager.Manager) {
 		setupLog.Error(err, "unable to create controller", "controller", "CloudStackMachine")
 		os.Exit(1)
 	}
-	// Temporarily disabling machine state checker until we can solve the issue of machines not always being replaced.
-	//if err := (&controllers.CloudStackMachineStateCheckerReconciler{ReconcilerBase: base}).SetupWithManager(mgr); err != nil {
-	//	setupLog.Error(err, "unable to create controller", "controller", "CloudStackMachineStateChecker")
-	//	os.Exit(1)
-	//}
 	if err := (&controllers.CloudStackIsoNetReconciler{ReconcilerBase: base}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CloudStackIsoNetReconciler")
 		os.Exit(1)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Disabling machine state checker

*Testing performed:*
- Created a cluster with an unreachable control plane machine.  Verified that machine state checker didn't delete the machine.
- Created a cluster normally and verified that creation succeeded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->