### PR TITLE
Addressing bug where account/domain was lost

### DIFF
--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	conv "k8s.io/apimachinery/pkg/conversion"
@@ -49,6 +50,9 @@ func Convert_v1beta1_CloudStackCluster_To_v1beta2_CloudStackCluster(in *CloudSta
 
 //nolint:golint,revive,stylecheck
 func Convert_v1beta2_CloudStackCluster_To_v1beta1_CloudStackCluster(in *v1beta2.CloudStackCluster, out *CloudStackCluster, scope conv.Scope) error {
+	if len(in.Spec.FailureDomains) < 1 {
+		return fmt.Errorf("v1beta2 to v1beta1 conversion not supported when ")
+	}
 	out.ObjectMeta = in.ObjectMeta
 	out.Spec = CloudStackClusterSpec{
 		Account:              in.Spec.FailureDomains[0].Account,

--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -51,7 +51,7 @@ func Convert_v1beta1_CloudStackCluster_To_v1beta2_CloudStackCluster(in *CloudSta
 //nolint:golint,revive,stylecheck
 func Convert_v1beta2_CloudStackCluster_To_v1beta1_CloudStackCluster(in *v1beta2.CloudStackCluster, out *CloudStackCluster, scope conv.Scope) error {
 	if len(in.Spec.FailureDomains) < 1 {
-		return fmt.Errorf("v1beta2 to v1beta1 conversion not supported when ")
+		return fmt.Errorf("v1beta2 to v1beta1 conversion not supported when < 1 failure domain is provided. Input CloudStackCluster spec %s", in.Spec)
 	}
 	out.ObjectMeta = in.ObjectMeta
 	out.Spec = CloudStackClusterSpec{

--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -51,6 +51,8 @@ func Convert_v1beta1_CloudStackCluster_To_v1beta2_CloudStackCluster(in *CloudSta
 func Convert_v1beta2_CloudStackCluster_To_v1beta1_CloudStackCluster(in *v1beta2.CloudStackCluster, out *CloudStackCluster, scope conv.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.Spec = CloudStackClusterSpec{
+		Account:              in.Spec.FailureDomains[0].Account,
+		Domain:               in.Spec.FailureDomains[0].Domain,
 		Zones:                getZones(in),
 		ControlPlaneEndpoint: in.Spec.ControlPlaneEndpoint,
 	}

--- a/api/v1beta1/conversion_test.go
+++ b/api/v1beta1/conversion_test.go
@@ -26,6 +26,8 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
+
+
 var _ = Describe("Conversion", func() {
 	BeforeEach(func() { // Reset test vars to initial state.
 	})
@@ -73,6 +75,85 @@ var _ = Describe("Conversion", func() {
 			}
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(failureDomains).Should(Equal(expectedResult))
+		})
+	})
+
+	Context("v1beta2 to v1beta1 function", func() {
+		It("Converts v1beta2 cluster spec to v1beta1 zone based cluster spec", func() {
+			csCluster := &v1beta2.CloudStackCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster1",
+					Namespace: "namespace1",
+				},
+				Spec: v1beta2.CloudStackClusterSpec{
+					FailureDomains: []v1beta2.CloudStackFailureDomainSpec{
+						{
+							Name: "76472a84-d23f-4e97-b154-ee1b975ed936",
+							Zone: v1beta2.CloudStackZoneSpec{
+								ID:      "76472a84-d23f-4e97-b154-ee1b975ed936",
+								Network: v1beta2.Network{Name: "network1"},
+							},
+							Account: "account1",
+							Domain:  "domain1",
+							ACSEndpoint: corev1.SecretReference{
+								Name:      "global",
+								Namespace: "namespace1",
+							},
+						},
+					},
+					ControlPlaneEndpoint: capiv1.APIEndpoint{
+						Host: "endpoint1",
+						Port: 443,
+					},
+				},
+				Status: v1beta2.CloudStackClusterStatus{},
+			}
+			converted := &v1beta1.CloudStackCluster{}
+			err := v1beta1.Convert_v1beta2_CloudStackCluster_To_v1beta1_CloudStackCluster(csCluster, converted, nil)
+			expectedResult := &v1beta1.CloudStackCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster1",
+					Namespace: "namespace1",
+				},
+				Spec: v1beta1.CloudStackClusterSpec{
+					Zones: []v1beta1.Zone{
+						{
+							ID: "76472a84-d23f-4e97-b154-ee1b975ed936",
+							Network: v1beta1.Network{
+								Name: "network1",
+							},
+						},
+					},
+					ControlPlaneEndpoint: capiv1.APIEndpoint{
+						Host: "endpoint1",
+						Port: 443,
+					},
+					Account: "account1",
+					Domain:  "domain1",
+				},
+				Status: v1beta1.CloudStackClusterStatus{},
+			}
+
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(converted).Should(Equal(expectedResult))
+		})
+
+		It("Returns error when len(failureDomains) < 1", func() {
+			csCluster := &v1beta2.CloudStackCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster1",
+					Namespace: "namespace1",
+				},
+				Spec: v1beta2.CloudStackClusterSpec{
+					ControlPlaneEndpoint: capiv1.APIEndpoint{
+						Host: "endpoint1",
+						Port: 443,
+					},
+				},
+				Status: v1beta2.CloudStackClusterStatus{},
+			}
+			err := v1beta1.Convert_v1beta2_CloudStackCluster_To_v1beta1_CloudStackCluster(csCluster, nil, nil)
+			Ω(err).Should(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While upgrading from EKS-A v0.10.1 to the latest version (with latest CAPC), I observed that the account/domain information vanished from the CloudStackCluster spec. I suspect that as part of the EKS-A upgrade, we somehow end up performing a conversion from v1beta2 to v1beta1 and lose this context. 

*Testing performed:*
Upgrade did not cause account/domain information to be lost.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->