### PR TITLE
Fixing go mod, otherwise eks-anywhere-build-tooling complains about inconsistent go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/cluster-api-provider-cloudstack
 go 1.16
 
 require (
-	github.com/ReneKroon/ttlcache v1.7.0 // indirect
+	github.com/ReneKroon/ttlcache v1.7.0
 	github.com/apache/cloudstack-go/v2 v2.13.0
 	github.com/go-logr/logr v1.2.3
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When I tried building the v0.4.7-rc2 (and rc1) locally in eks-anywhere-build-tooling, it complained that
```
go generate ./...
go: inconsistent vendoring in /Users/dribinm/workspaces/eksa/eks-anywhere-build-tooling/projects/kubernetes-sigs/cluster-api-provider-cloudstack/cluster-api-provider-cloudstack:
	github.com/ReneKroon/ttlcache@v1.7.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/apache/cloudstack-go/v2@v2.13.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/go-logr/logr@v1.2.3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/golang/mock@v1.6.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/hashicorp/go-multierror@v1.1.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/onsi/ginkgo/v2@v2.1.4: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/onsi/gomega@v1.19.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/pkg/errors@v0.9.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/prometheus/client_golang@v1.11.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/smallfish/simpleyaml@v0.1.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/spf13/pflag@v1.0.5: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/api@v0.23.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/apimachinery@v0.23.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/client-go@v0.23.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/klog/v2@v2.30.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	k8s.io/utils@v0.0.0-20210930125809-cb0fa318a74b: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	sigs.k8s.io/cluster-api@v1.0.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	sigs.k8s.io/controller-runtime@v0.11.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/dgrijalva/jwt-go: is replaced in go.mod, but not marked as replaced in vendor/modules.txt

	To ignore the vendor directory, use -mod=readonly or -mod=mod.
	To sync the vendor directory, run:
		go mod vendor
make[1]: *** [pkg/mocks/mock_client.go] Error 1
make: *** [cluster-api-provider-cloudstack/pkg/mocks/mock_client.go] Error 2
```

So I ran go mod tidy to clean up

*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->