### PR TITLE
customize v1beta1 affinity group conversion to v1beta2

### DIFF
--- a/api/v1beta1/cloudstackaffinitygroup_conversion.go
+++ b/api/v1beta1/cloudstackaffinitygroup_conversion.go
@@ -17,7 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
+	conv "k8s.io/apimachinery/pkg/conversion"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
@@ -29,4 +32,45 @@ func (src *CloudStackAffinityGroup) ConvertTo(dstRaw conversion.Hub) error { // 
 func (dst *CloudStackAffinityGroup) ConvertFrom(srcRaw conversion.Hub) error { // nolint
 	src := srcRaw.(*v1beta2.CloudStackAffinityGroup)
 	return Convert_v1beta2_CloudStackAffinityGroup_To_v1beta1_CloudStackAffinityGroup(src, dst, nil)
+}
+
+//nolint:golint,revive,stylecheck
+func Convert_v1beta1_CloudStackAffinityGroup_To_v1beta2_CloudStackAffinityGroup(in *CloudStackAffinityGroup, out *v1beta2.CloudStackAffinityGroup, s conv.Scope) error {
+	out.ObjectMeta = in.ObjectMeta
+
+	csCluster := &v1beta2.CloudStackCluster{}
+	clusterName := in.ObjectMeta.Labels["cluster.x-k8s.io/cluster-name"]
+	namespace := in.ObjectMeta.Namespace
+	key := client.ObjectKey{Name: clusterName, Namespace: namespace}
+	if err := v1beta2.K8sClient.Get(context.TODO(), key, csCluster); err != nil {
+		return err
+	}
+
+	out.Spec = v1beta2.CloudStackAffinityGroupSpec{
+		Type:              in.Spec.Type,
+		Name:              in.Spec.Name,
+		ID:                in.Spec.ID,
+		FailureDomainName: csCluster.Spec.FailureDomains[0].Name,
+	}
+
+	out.Status = v1beta2.CloudStackAffinityGroupStatus{
+		Ready: in.Status.Ready,
+	}
+	return nil
+}
+
+//nolint:golint,revive,stylecheck
+func Convert_v1beta2_CloudStackAffinityGroup_To_v1beta1_CloudStackAffinityGroup(in *v1beta2.CloudStackAffinityGroup, out *CloudStackAffinityGroup, s conv.Scope) error {
+	out.ObjectMeta = in.ObjectMeta
+
+	out.Spec = CloudStackAffinityGroupSpec{
+		Type: in.Spec.Type,
+		Name: in.Spec.Name,
+		ID:   in.Spec.ID,
+	}
+
+	out.Status = CloudStackAffinityGroupStatus{
+		Ready: in.Status.Ready,
+	}
+	return nil
 }

--- a/api/v1beta1/cloudstackaffinitygroup_types.go
+++ b/api/v1beta1/cloudstackaffinitygroup_types.go
@@ -24,6 +24,7 @@ const (
 	AffinityGroupFinalizer = "affinitygroup.infrastructure.cluster.x-k8s.io"
 )
 
+//+k8s:conversion-gen=false
 // CloudStackAffinityGroupSpec defines the desired state of CloudStackAffinityGroup
 type CloudStackAffinityGroupSpec struct {
 	// Mutually exclusive parameter with AffinityGroupIDs.
@@ -38,6 +39,7 @@ type CloudStackAffinityGroupSpec struct {
 	ID string `json:"id,omitempty"`
 }
 
+//+k8s:conversion-gen=false
 // CloudStackAffinityGroupStatus defines the observed state of CloudStackAffinityGroup
 type CloudStackAffinityGroupStatus struct {
 	// Reflects the readiness of the CS Affinity Group.
@@ -46,7 +48,7 @@ type CloudStackAffinityGroupStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-
+//+k8s:conversion-gen=false
 // CloudStackAffinityGroup is the Schema for the cloudstackaffinitygroups API
 type CloudStackAffinityGroup struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1beta1/conversion_test.go
+++ b/api/v1beta1/conversion_test.go
@@ -26,8 +26,6 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-
-
 var _ = Describe("Conversion", func() {
 	BeforeEach(func() { // Reset test vars to initial state.
 	})

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -33,16 +33,6 @@ func init() {
 // RegisterConversions adds conversion functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterConversions(s *runtime.Scheme) error {
-	if err := s.AddGeneratedConversionFunc((*CloudStackAffinityGroup)(nil), (*v1beta2.CloudStackAffinityGroup)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_CloudStackAffinityGroup_To_v1beta2_CloudStackAffinityGroup(a.(*CloudStackAffinityGroup), b.(*v1beta2.CloudStackAffinityGroup), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.CloudStackAffinityGroup)(nil), (*CloudStackAffinityGroup)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_CloudStackAffinityGroup_To_v1beta1_CloudStackAffinityGroup(a.(*v1beta2.CloudStackAffinityGroup), b.(*CloudStackAffinityGroup), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*CloudStackAffinityGroupList)(nil), (*v1beta2.CloudStackAffinityGroupList)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta1_CloudStackAffinityGroupList_To_v1beta2_CloudStackAffinityGroupList(a.(*CloudStackAffinityGroupList), b.(*v1beta2.CloudStackAffinityGroupList), scope)
 	}); err != nil {
@@ -50,26 +40,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddGeneratedConversionFunc((*v1beta2.CloudStackAffinityGroupList)(nil), (*CloudStackAffinityGroupList)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_CloudStackAffinityGroupList_To_v1beta1_CloudStackAffinityGroupList(a.(*v1beta2.CloudStackAffinityGroupList), b.(*CloudStackAffinityGroupList), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*CloudStackAffinityGroupSpec)(nil), (*v1beta2.CloudStackAffinityGroupSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_CloudStackAffinityGroupSpec_To_v1beta2_CloudStackAffinityGroupSpec(a.(*CloudStackAffinityGroupSpec), b.(*v1beta2.CloudStackAffinityGroupSpec), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.CloudStackAffinityGroupSpec)(nil), (*CloudStackAffinityGroupSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_CloudStackAffinityGroupSpec_To_v1beta1_CloudStackAffinityGroupSpec(a.(*v1beta2.CloudStackAffinityGroupSpec), b.(*CloudStackAffinityGroupSpec), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*CloudStackAffinityGroupStatus)(nil), (*v1beta2.CloudStackAffinityGroupStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_CloudStackAffinityGroupStatus_To_v1beta2_CloudStackAffinityGroupStatus(a.(*CloudStackAffinityGroupStatus), b.(*v1beta2.CloudStackAffinityGroupStatus), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.CloudStackAffinityGroupStatus)(nil), (*CloudStackAffinityGroupStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_CloudStackAffinityGroupStatus_To_v1beta1_CloudStackAffinityGroupStatus(a.(*v1beta2.CloudStackAffinityGroupStatus), b.(*CloudStackAffinityGroupStatus), scope)
 	}); err != nil {
 		return err
 	}
@@ -273,8 +243,18 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*CloudStackAffinityGroup)(nil), (*v1beta2.CloudStackAffinityGroup)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta1_CloudStackAffinityGroup_To_v1beta2_CloudStackAffinityGroup(a.(*CloudStackAffinityGroup), b.(*v1beta2.CloudStackAffinityGroup), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*CloudStackCluster)(nil), (*v1beta2.CloudStackCluster)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta1_CloudStackCluster_To_v1beta2_CloudStackCluster(a.(*CloudStackCluster), b.(*v1beta2.CloudStackCluster), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.CloudStackAffinityGroup)(nil), (*CloudStackAffinityGroup)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_CloudStackAffinityGroup_To_v1beta1_CloudStackAffinityGroup(a.(*v1beta2.CloudStackAffinityGroup), b.(*CloudStackAffinityGroup), scope)
 	}); err != nil {
 		return err
 	}
@@ -284,38 +264,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 		return err
 	}
 	return nil
-}
-
-func autoConvert_v1beta1_CloudStackAffinityGroup_To_v1beta2_CloudStackAffinityGroup(in *CloudStackAffinityGroup, out *v1beta2.CloudStackAffinityGroup, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := Convert_v1beta1_CloudStackAffinityGroupSpec_To_v1beta2_CloudStackAffinityGroupSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
-	if err := Convert_v1beta1_CloudStackAffinityGroupStatus_To_v1beta2_CloudStackAffinityGroupStatus(&in.Status, &out.Status, s); err != nil {
-		return err
-	}
-	return nil
-}
-
-// Convert_v1beta1_CloudStackAffinityGroup_To_v1beta2_CloudStackAffinityGroup is an autogenerated conversion function.
-func Convert_v1beta1_CloudStackAffinityGroup_To_v1beta2_CloudStackAffinityGroup(in *CloudStackAffinityGroup, out *v1beta2.CloudStackAffinityGroup, s conversion.Scope) error {
-	return autoConvert_v1beta1_CloudStackAffinityGroup_To_v1beta2_CloudStackAffinityGroup(in, out, s)
-}
-
-func autoConvert_v1beta2_CloudStackAffinityGroup_To_v1beta1_CloudStackAffinityGroup(in *v1beta2.CloudStackAffinityGroup, out *CloudStackAffinityGroup, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
-	if err := Convert_v1beta2_CloudStackAffinityGroupSpec_To_v1beta1_CloudStackAffinityGroupSpec(&in.Spec, &out.Spec, s); err != nil {
-		return err
-	}
-	if err := Convert_v1beta2_CloudStackAffinityGroupStatus_To_v1beta1_CloudStackAffinityGroupStatus(&in.Status, &out.Status, s); err != nil {
-		return err
-	}
-	return nil
-}
-
-// Convert_v1beta2_CloudStackAffinityGroup_To_v1beta1_CloudStackAffinityGroup is an autogenerated conversion function.
-func Convert_v1beta2_CloudStackAffinityGroup_To_v1beta1_CloudStackAffinityGroup(in *v1beta2.CloudStackAffinityGroup, out *CloudStackAffinityGroup, s conversion.Scope) error {
-	return autoConvert_v1beta2_CloudStackAffinityGroup_To_v1beta1_CloudStackAffinityGroup(in, out, s)
 }
 
 func autoConvert_v1beta1_CloudStackAffinityGroupList_To_v1beta2_CloudStackAffinityGroupList(in *CloudStackAffinityGroupList, out *v1beta2.CloudStackAffinityGroupList, s conversion.Scope) error {
@@ -358,51 +306,6 @@ func autoConvert_v1beta2_CloudStackAffinityGroupList_To_v1beta1_CloudStackAffini
 // Convert_v1beta2_CloudStackAffinityGroupList_To_v1beta1_CloudStackAffinityGroupList is an autogenerated conversion function.
 func Convert_v1beta2_CloudStackAffinityGroupList_To_v1beta1_CloudStackAffinityGroupList(in *v1beta2.CloudStackAffinityGroupList, out *CloudStackAffinityGroupList, s conversion.Scope) error {
 	return autoConvert_v1beta2_CloudStackAffinityGroupList_To_v1beta1_CloudStackAffinityGroupList(in, out, s)
-}
-
-func autoConvert_v1beta1_CloudStackAffinityGroupSpec_To_v1beta2_CloudStackAffinityGroupSpec(in *CloudStackAffinityGroupSpec, out *v1beta2.CloudStackAffinityGroupSpec, s conversion.Scope) error {
-	out.Type = in.Type
-	out.Name = in.Name
-	out.ID = in.ID
-	return nil
-}
-
-// Convert_v1beta1_CloudStackAffinityGroupSpec_To_v1beta2_CloudStackAffinityGroupSpec is an autogenerated conversion function.
-func Convert_v1beta1_CloudStackAffinityGroupSpec_To_v1beta2_CloudStackAffinityGroupSpec(in *CloudStackAffinityGroupSpec, out *v1beta2.CloudStackAffinityGroupSpec, s conversion.Scope) error {
-	return autoConvert_v1beta1_CloudStackAffinityGroupSpec_To_v1beta2_CloudStackAffinityGroupSpec(in, out, s)
-}
-
-func autoConvert_v1beta2_CloudStackAffinityGroupSpec_To_v1beta1_CloudStackAffinityGroupSpec(in *v1beta2.CloudStackAffinityGroupSpec, out *CloudStackAffinityGroupSpec, s conversion.Scope) error {
-	out.Type = in.Type
-	out.Name = in.Name
-	out.ID = in.ID
-	// INFO: in.FailureDomainName opted out of conversion generation
-	return nil
-}
-
-// Convert_v1beta2_CloudStackAffinityGroupSpec_To_v1beta1_CloudStackAffinityGroupSpec is an autogenerated conversion function.
-func Convert_v1beta2_CloudStackAffinityGroupSpec_To_v1beta1_CloudStackAffinityGroupSpec(in *v1beta2.CloudStackAffinityGroupSpec, out *CloudStackAffinityGroupSpec, s conversion.Scope) error {
-	return autoConvert_v1beta2_CloudStackAffinityGroupSpec_To_v1beta1_CloudStackAffinityGroupSpec(in, out, s)
-}
-
-func autoConvert_v1beta1_CloudStackAffinityGroupStatus_To_v1beta2_CloudStackAffinityGroupStatus(in *CloudStackAffinityGroupStatus, out *v1beta2.CloudStackAffinityGroupStatus, s conversion.Scope) error {
-	out.Ready = in.Ready
-	return nil
-}
-
-// Convert_v1beta1_CloudStackAffinityGroupStatus_To_v1beta2_CloudStackAffinityGroupStatus is an autogenerated conversion function.
-func Convert_v1beta1_CloudStackAffinityGroupStatus_To_v1beta2_CloudStackAffinityGroupStatus(in *CloudStackAffinityGroupStatus, out *v1beta2.CloudStackAffinityGroupStatus, s conversion.Scope) error {
-	return autoConvert_v1beta1_CloudStackAffinityGroupStatus_To_v1beta2_CloudStackAffinityGroupStatus(in, out, s)
-}
-
-func autoConvert_v1beta2_CloudStackAffinityGroupStatus_To_v1beta1_CloudStackAffinityGroupStatus(in *v1beta2.CloudStackAffinityGroupStatus, out *CloudStackAffinityGroupStatus, s conversion.Scope) error {
-	out.Ready = in.Ready
-	return nil
-}
-
-// Convert_v1beta2_CloudStackAffinityGroupStatus_To_v1beta1_CloudStackAffinityGroupStatus is an autogenerated conversion function.
-func Convert_v1beta2_CloudStackAffinityGroupStatus_To_v1beta1_CloudStackAffinityGroupStatus(in *v1beta2.CloudStackAffinityGroupStatus, out *CloudStackAffinityGroupStatus, s conversion.Scope) error {
-	return autoConvert_v1beta2_CloudStackAffinityGroupStatus_To_v1beta1_CloudStackAffinityGroupStatus(in, out, s)
 }
 
 func autoConvert_v1beta1_CloudStackIsolatedNetwork_To_v1beta2_CloudStackIsolatedNetwork(in *CloudStackIsolatedNetwork, out *v1beta2.CloudStackIsolatedNetwork, s conversion.Scope) error {

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -21,10 +21,10 @@ patchesStrategicMerge:
 - patches/webhook_in_cloudstackmachines.yaml
 - patches/webhook_in_cloudstackmachinetemplates.yaml
 - patches/webhook_in_cloudstackisolatednetworks.yaml
-- patches/webhook_in_cloudstackzones.yaml
+# - patches/webhook_in_cloudstackzones.yaml
 - patches/webhook_in_cloudstackaffinitygroups.yaml
 - patches/webhook_in_cloudstackmachinestatecheckers.yaml
-- patches/webhook_in_cloudstackfailuredomains.yaml
+# - patches/webhook_in_cloudstackfailuredomains.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # patches here are for enabling the CA injection for each CRD


### PR DESCRIPTION
*Issue #, if available:*
Add default failure domain name when converting v1beta1 affinity group to v1beta2 affinity group. This is only needed when upgrade 
*Description of changes:*
Assign first failure domain name to v1beta1 affinity groups since the first failure domain is the previous version's only failure domain.

Commented out cloudstackZone and cloudstackfailuredomain patch since cloudstackZone does not exist in v1beta2 and cloudstackFailuredomain does not exist in v1beta1
*Testing performed:*
Manually tested. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->