### PR TITLE
Ported templates to v1beta2

### DIFF
--- a/templates/cluster-template-managed-ssh.yaml
+++ b/templates/cluster-template-managed-ssh.yaml
@@ -29,7 +29,7 @@ spec:
   failureDomains:
     - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
       acsEndpoint:
-        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudStackCredentials}
+        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudstack-credentials}
         namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
         name :  ${CLOUDSTACK_ZONE_NAME}

--- a/templates/cluster-template-managed-ssh.yaml
+++ b/templates/cluster-template-managed-ssh.yaml
@@ -29,8 +29,8 @@ spec:
   failureDomains:
     - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
       acsEndpoint:
-        name: ${CLOUDSTACK_FD1_SECRET_NAME}
-        namespace: default
+        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudStackCredentials}
+        namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
         name :  ${CLOUDSTACK_ZONE_NAME}
         network:

--- a/templates/cluster-template-managed-ssh.yaml
+++ b/templates/cluster-template-managed-ssh.yaml
@@ -32,7 +32,7 @@ spec:
         name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudstack-credentials}
         namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
-        name :  ${CLOUDSTACK_ZONE_NAME}
+        name:  ${CLOUDSTACK_ZONE_NAME}
         network:
           name: ${CLOUDSTACK_NETWORK_NAME}
 ---

--- a/templates/cluster-template-managed-ssh.yaml
+++ b/templates/cluster-template-managed-ssh.yaml
@@ -8,9 +8,9 @@ spec:
     pods:
       cidrBlocks:
         - 192.168.0.0/16
-    serviceDomain: cluster.local
+    serviceDomain: "cluster.local"
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: CloudStackCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -18,48 +18,51 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     name: ${CLUSTER_NAME}-control-plane
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
   controlPlaneEndpoint:
     host: ${CLUSTER_ENDPOINT_IP}
-    port: ${CLUSTER_ENDPOINT_PORT}
-  zones:
-  - name : ${CLOUDSTACK_ZONE_NAME}
-    network: 
-      name: ${CLOUDSTACK_NETWORK_NAME}
+    port: ${CLUSTER_ENDPOINT_PORT=6443}
+  failureDomains:
+    - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
+      acsEndpoint:
+        name: ${CLOUDSTACK_FD1_SECRET_NAME}
+        namespace: default
+      zone:
+        name :  ${CLOUDSTACK_ZONE_NAME}
+        network:
+          name: ${CLOUDSTACK_NETWORK_NAME}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   kubeadmConfigSpec:
-    clusterConfiguration:
-      imageRepository: k8s.gcr.io
     initConfiguration:
       nodeRegistration:
+        name: '{{ local_hostname }}'
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-        name: '{{ local_hostname }}'
     joinConfiguration:
       nodeRegistration:
+        name: '{{ local_hostname }}'
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-        name: '{{ local_hostname }}'
     preKubeadmCommands:
       - swapoff -a
   machineTemplate:
     infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: CloudStackMachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       name: "${CLUSTER_NAME}-control-plane"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -69,7 +72,7 @@ spec:
       sshKey: ${CLOUDSTACK_SSH_KEY_NAME}
       offering: 
         name: ${CLOUDSTACK_CONTROL_PLANE_MACHINE_OFFERING}
-      template: 
+      template:
         name: ${CLOUDSTACK_TEMPLATE_NAME}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -83,19 +86,19 @@ spec:
     matchLabels: null
   template:
     spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
       bootstrap:
         configRef:
+          name: "${CLUSTER_NAME}-md-0"
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: "${CLUSTER_NAME}-md-0"
-      clusterName: "${CLUSTER_NAME}"
       infrastructureRef:
         name: "${CLUSTER_NAME}-md-0"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: CloudStackMachineTemplate
-      version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
@@ -105,7 +108,7 @@ spec:
       sshKey: ${CLOUDSTACK_SSH_KEY_NAME}
       offering: 
         name: ${CLOUDSTACK_WORKER_MACHINE_OFFERING}
-      template: 
+      template:
         name: ${CLOUDSTACK_TEMPLATE_NAME}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -117,8 +120,8 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
+          name: '{{ local_hostname }}'
           kubeletExtraArgs:
             provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-          name: '{{ local_hostname }}'
       preKubeadmCommands:
         - swapoff -a

--- a/templates/cluster-template-ssh-material.yaml
+++ b/templates/cluster-template-ssh-material.yaml
@@ -29,7 +29,7 @@ spec:
   failureDomains:
     - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
       acsEndpoint:
-        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudStackCredentials}
+        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudstack-credentials}
         namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
         name :  ${CLOUDSTACK_ZONE_NAME}

--- a/templates/cluster-template-ssh-material.yaml
+++ b/templates/cluster-template-ssh-material.yaml
@@ -29,8 +29,8 @@ spec:
   failureDomains:
     - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
       acsEndpoint:
-        name: ${CLOUDSTACK_FD1_SECRET_NAME}
-        namespace: default
+        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudStackCredentials}
+        namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
         name :  ${CLOUDSTACK_ZONE_NAME}
         network:

--- a/templates/cluster-template-ssh-material.yaml
+++ b/templates/cluster-template-ssh-material.yaml
@@ -32,7 +32,7 @@ spec:
         name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudstack-credentials}
         namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
-        name :  ${CLOUDSTACK_ZONE_NAME}
+        name:  ${CLOUDSTACK_ZONE_NAME}
         network:
           name: ${CLOUDSTACK_NETWORK_NAME}
 ---

--- a/templates/cluster-template-ssh-material.yaml
+++ b/templates/cluster-template-ssh-material.yaml
@@ -8,9 +8,9 @@ spec:
     pods:
       cidrBlocks:
         - 192.168.0.0/16
-    serviceDomain: cluster.local
+    serviceDomain: "cluster.local"
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: CloudStackCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -18,37 +18,40 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     name: ${CLUSTER_NAME}-control-plane
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
   controlPlaneEndpoint:
     host: ${CLUSTER_ENDPOINT_IP}
-    port: ${CLUSTER_ENDPOINT_PORT}
-  zones:
-  - name : ${CLOUDSTACK_ZONE_NAME}
-    network: 
-      name: ${CLOUDSTACK_NETWORK_NAME}
+    port: ${CLUSTER_ENDPOINT_PORT=6443}
+  failureDomains:
+    - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
+      acsEndpoint:
+        name: ${CLOUDSTACK_FD1_SECRET_NAME}
+        namespace: default
+      zone:
+        name :  ${CLOUDSTACK_ZONE_NAME}
+        network:
+          name: ${CLOUDSTACK_NETWORK_NAME}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   kubeadmConfigSpec:
-    clusterConfiguration:
-      imageRepository: k8s.gcr.io
     initConfiguration:
       nodeRegistration:
+        name: '{{ local_hostname }}'
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-        name: '{{ local_hostname }}'
     joinConfiguration:
       nodeRegistration:
+        name: '{{ local_hostname }}'
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-        name: '{{ local_hostname }}'
     users:
       - name: ${OS_USERID}
         sshAuthorizedKeys:
@@ -58,22 +61,22 @@ spec:
       - swapoff -a
   machineTemplate:
     infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: CloudStackMachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       name: "${CLUSTER_NAME}-control-plane"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
 spec:
   template:
     spec:
-      offering: 
+      offering:
         name: ${CLOUDSTACK_CONTROL_PLANE_MACHINE_OFFERING}
-      template: 
+      template:
         name: ${CLOUDSTACK_TEMPLATE_NAME}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -87,28 +90,28 @@ spec:
     matchLabels: null
   template:
     spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
       bootstrap:
         configRef:
+          name: "${CLUSTER_NAME}-md-0"
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: "${CLUSTER_NAME}-md-0"
-      clusterName: "${CLUSTER_NAME}"
       infrastructureRef:
         name: "${CLUSTER_NAME}-md-0"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: CloudStackMachineTemplate
-      version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
 spec:
   template:
     spec:
-      offering: 
+      offering:
         name: ${CLOUDSTACK_WORKER_MACHINE_OFFERING}
-      template: 
+      template:
         name: ${CLOUDSTACK_TEMPLATE_NAME}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -120,9 +123,9 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
+          name: '{{ local_hostname }}'
           kubeletExtraArgs:
             provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-          name: '{{ local_hostname }}'
       users:
         - name: ${OS_USERID}
           sshAuthorizedKeys:

--- a/templates/cluster-template-with-disk-offering.yaml
+++ b/templates/cluster-template-with-disk-offering.yaml
@@ -8,9 +8,9 @@ spec:
     pods:
       cidrBlocks:
         - 192.168.0.0/16
-    serviceDomain: cluster.local
+    serviceDomain: "cluster.local"
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: CloudStackCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -18,37 +18,40 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     name: ${CLUSTER_NAME}-control-plane
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
   controlPlaneEndpoint:
     host: ${CLUSTER_ENDPOINT_IP}
-    port: ${CLUSTER_ENDPOINT_PORT}
-  zones:
-  - name : ${CLOUDSTACK_ZONE_NAME}
-    network: 
-      name: ${CLOUDSTACK_NETWORK_NAME}
+    port: ${CLUSTER_ENDPOINT_PORT=6443}
+  failureDomains:
+    - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
+      acsEndpoint:
+        name: ${CLOUDSTACK_FD1_SECRET_NAME}
+        namespace: default
+      zone:
+        name :  ${CLOUDSTACK_ZONE_NAME}
+        network:
+          name: ${CLOUDSTACK_NETWORK_NAME}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   kubeadmConfigSpec:
-    clusterConfiguration:
-      imageRepository: k8s.gcr.io
     initConfiguration:
       nodeRegistration:
+        name: '{{ local_hostname }}'
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-        name: '{{ local_hostname }}'
     joinConfiguration:
       nodeRegistration:
+        name: '{{ local_hostname }}'
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-        name: '{{ local_hostname }}'
         ignorePreflightErrors:
           - DirAvailable--etc-kubernetes-manifests
     preKubeadmCommands:
@@ -72,22 +75,28 @@ spec:
         - ${CLOUDSTACK_DISK_OFFERING_MOUNT_PATH}
   machineTemplate:
     infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: CloudStackMachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       name: "${CLUSTER_NAME}-control-plane"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
 spec:
   template:
     spec:
-      offering: 
+      offering:
         name: ${CLOUDSTACK_CONTROL_PLANE_MACHINE_OFFERING}
-      template: 
+      diskOffering:
+        name: ${CLOUDSTACK_DISK_OFFERING_NAME}
+        mountPath: ${CLOUDSTACK_DISK_OFFERING_MOUNT_PATH}
+        device: ${CLOUDSTACK_DISK_OFFERING_DEVICE}
+        filesystem: ${CLOUDSTACK_DISK_OFFERING_FILESYSTEM}
+        label: ${CLOUDSTACK_DISK_OFFERING_LABEL}
+      template:
         name: ${CLOUDSTACK_TEMPLATE_NAME}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -101,28 +110,34 @@ spec:
     matchLabels: null
   template:
     spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
       bootstrap:
         configRef:
+          name: "${CLUSTER_NAME}-md-0"
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: "${CLUSTER_NAME}-md-0"
-      clusterName: "${CLUSTER_NAME}"
       infrastructureRef:
         name: "${CLUSTER_NAME}-md-0"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: CloudStackMachineTemplate
-      version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
 spec:
   template:
     spec:
-      offering: 
+      offering:
         name: ${CLOUDSTACK_WORKER_MACHINE_OFFERING}
-      template: 
+      diskOffering:
+        name: ${CLOUDSTACK_DISK_OFFERING_NAME}
+        mountPath: ${CLOUDSTACK_DISK_OFFERING_MOUNT_PATH}
+        device: ${CLOUDSTACK_DISK_OFFERING_DEVICE}
+        filesystem: ${CLOUDSTACK_DISK_OFFERING_FILESYSTEM}
+        label: ${CLOUDSTACK_DISK_OFFERING_LABEL}
+      template:
         name: ${CLOUDSTACK_TEMPLATE_NAME}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -134,9 +149,9 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
+          name: '{{ local_hostname }}'
           kubeletExtraArgs:
             provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-          name: '{{ local_hostname }}'
       preKubeadmCommands:
         - swapoff -a
       diskSetup:

--- a/templates/cluster-template-with-disk-offering.yaml
+++ b/templates/cluster-template-with-disk-offering.yaml
@@ -29,7 +29,7 @@ spec:
   failureDomains:
     - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
       acsEndpoint:
-        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudStackCredentials}
+        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudstack-credentials}
         namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
         name :  ${CLOUDSTACK_ZONE_NAME}

--- a/templates/cluster-template-with-disk-offering.yaml
+++ b/templates/cluster-template-with-disk-offering.yaml
@@ -29,8 +29,8 @@ spec:
   failureDomains:
     - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
       acsEndpoint:
-        name: ${CLOUDSTACK_FD1_SECRET_NAME}
-        namespace: default
+        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudStackCredentials}
+        namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
         name :  ${CLOUDSTACK_ZONE_NAME}
         network:

--- a/templates/cluster-template-with-disk-offering.yaml
+++ b/templates/cluster-template-with-disk-offering.yaml
@@ -32,7 +32,7 @@ spec:
         name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudstack-credentials}
         namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
-        name :  ${CLOUDSTACK_ZONE_NAME}
+        name:  ${CLOUDSTACK_ZONE_NAME}
         network:
           name: ${CLOUDSTACK_NETWORK_NAME}
 ---

--- a/templates/cluster-template-with-kube-vip.yaml
+++ b/templates/cluster-template-with-kube-vip.yaml
@@ -29,7 +29,7 @@ spec:
   failureDomains:
     - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
       acsEndpoint:
-        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudStackCredentials}
+        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudstack-credentials}
         namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
         name :  ${CLOUDSTACK_ZONE_NAME}

--- a/templates/cluster-template-with-kube-vip.yaml
+++ b/templates/cluster-template-with-kube-vip.yaml
@@ -29,8 +29,8 @@ spec:
   failureDomains:
     - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
       acsEndpoint:
-        name: ${CLOUDSTACK_FD1_SECRET_NAME}
-        namespace: default
+        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudStackCredentials}
+        namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
         name :  ${CLOUDSTACK_ZONE_NAME}
         network:

--- a/templates/cluster-template-with-kube-vip.yaml
+++ b/templates/cluster-template-with-kube-vip.yaml
@@ -32,7 +32,7 @@ spec:
         name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudstack-credentials}
         namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
-        name :  ${CLOUDSTACK_ZONE_NAME}
+        name:  ${CLOUDSTACK_ZONE_NAME}
         network:
           name: ${CLOUDSTACK_NETWORK_NAME}
 ---

--- a/templates/cluster-template-with-kube-vip.yaml
+++ b/templates/cluster-template-with-kube-vip.yaml
@@ -8,9 +8,9 @@ spec:
     pods:
       cidrBlocks:
         - 192.168.0.0/16
-    serviceDomain: cluster.local
+    serviceDomain: "cluster.local"
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: CloudStackCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -18,37 +18,40 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     name: ${CLUSTER_NAME}-control-plane
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
   controlPlaneEndpoint:
     host: ${CLUSTER_ENDPOINT_IP}
-    port: ${CLUSTER_ENDPOINT_PORT}
-  zones:
-  - name : ${CLOUDSTACK_ZONE_NAME}
-    network: 
-      name: ${CLOUDSTACK_NETWORK_NAME}
+    port: ${CLUSTER_ENDPOINT_PORT=6443}
+  failureDomains:
+    - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
+      acsEndpoint:
+        name: ${CLOUDSTACK_FD1_SECRET_NAME}
+        namespace: default
+      zone:
+        name :  ${CLOUDSTACK_ZONE_NAME}
+        network:
+          name: ${CLOUDSTACK_NETWORK_NAME}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   kubeadmConfigSpec:
-    clusterConfiguration:
-      imageRepository: k8s.gcr.io
     initConfiguration:
       nodeRegistration:
+        name: '{{ local_hostname }}'
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-        name: '{{ local_hostname }}'
     joinConfiguration:
       nodeRegistration:
+        name: '{{ local_hostname }}'
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-        name: '{{ local_hostname }}'
         ignorePreflightErrors:
           - DirAvailable--etc-kubernetes-manifests
     preKubeadmCommands:
@@ -103,22 +106,22 @@ spec:
         path: /etc/kubernetes/manifests/kube-vip.yaml
   machineTemplate:
     infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: CloudStackMachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       name: "${CLUSTER_NAME}-control-plane"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
 spec:
   template:
     spec:
-      offering: 
+      offering:
         name: ${CLOUDSTACK_CONTROL_PLANE_MACHINE_OFFERING}
-      template: 
+      template:
         name: ${CLOUDSTACK_TEMPLATE_NAME}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -132,28 +135,28 @@ spec:
     matchLabels: null
   template:
     spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
       bootstrap:
         configRef:
+          name: "${CLUSTER_NAME}-md-0"
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: "${CLUSTER_NAME}-md-0"
-      clusterName: "${CLUSTER_NAME}"
       infrastructureRef:
         name: "${CLUSTER_NAME}-md-0"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: CloudStackMachineTemplate
-      version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
 spec:
   template:
     spec:
-      offering: 
+      offering:
         name: ${CLOUDSTACK_WORKER_MACHINE_OFFERING}
-      template: 
+      template:
         name: ${CLOUDSTACK_TEMPLATE_NAME}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -165,9 +168,8 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
+          name: '{{ local_hostname }}'
           kubeletExtraArgs:
             provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-          name: '{{ local_hostname }}'
       preKubeadmCommands:
         - swapoff -a
-

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -29,7 +29,7 @@ spec:
   failureDomains:
     - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
       acsEndpoint:
-        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudStackCredentials}
+        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudstack-credentials}
         namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
         name :  ${CLOUDSTACK_ZONE_NAME}

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -29,8 +29,8 @@ spec:
   failureDomains:
     - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
       acsEndpoint:
-        name: ${CLOUDSTACK_FD1_SECRET_NAME}
-        namespace: default
+        name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudStackCredentials}
+        namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
         name :  ${CLOUDSTACK_ZONE_NAME}
         network:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -32,7 +32,7 @@ spec:
         name: ${CLOUDSTACK_FD1_SECRET_NAME=cloudstack-credentials}
         namespace: ${CLOUDSTACK_FD1_SECRET_NAMESPACE=default}
       zone:
-        name :  ${CLOUDSTACK_ZONE_NAME}
+        name:  ${CLOUDSTACK_ZONE_NAME}
         network:
           name: ${CLOUDSTACK_NETWORK_NAME}
 ---

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -8,9 +8,9 @@ spec:
     pods:
       cidrBlocks:
         - 192.168.0.0/16
-    serviceDomain: cluster.local
+    serviceDomain: "cluster.local"
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: CloudStackCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -18,57 +18,60 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     name: ${CLUSTER_NAME}-control-plane
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
   controlPlaneEndpoint:
     host: ${CLUSTER_ENDPOINT_IP}
-    port: ${CLUSTER_ENDPOINT_PORT}
-  zones:
-  - name : ${CLOUDSTACK_ZONE_NAME}
-    network: 
-      name: ${CLOUDSTACK_NETWORK_NAME}
+    port: ${CLUSTER_ENDPOINT_PORT=6443}
+  failureDomains:
+    - name: ${CLOUDSTACK_FD1_NAME=failure-domain-1}
+      acsEndpoint:
+        name: ${CLOUDSTACK_FD1_SECRET_NAME}
+        namespace: default
+      zone:
+        name :  ${CLOUDSTACK_ZONE_NAME}
+        network:
+          name: ${CLOUDSTACK_NETWORK_NAME}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   kubeadmConfigSpec:
-    clusterConfiguration:
-      imageRepository: k8s.gcr.io
     initConfiguration:
       nodeRegistration:
+        name: '{{ local_hostname }}'
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-        name: '{{ local_hostname }}'
     joinConfiguration:
       nodeRegistration:
+        name: '{{ local_hostname }}'
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-        name: '{{ local_hostname }}'
     preKubeadmCommands:
       - swapoff -a
   machineTemplate:
     infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: CloudStackMachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       name: "${CLUSTER_NAME}-control-plane"
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
 spec:
   template:
     spec:
-      offering: 
+      offering:
         name: ${CLOUDSTACK_CONTROL_PLANE_MACHINE_OFFERING}
-      template: 
+      template:
         name: ${CLOUDSTACK_TEMPLATE_NAME}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -82,28 +85,28 @@ spec:
     matchLabels: null
   template:
     spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
       bootstrap:
         configRef:
+          name: "${CLUSTER_NAME}-md-0"
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: "${CLUSTER_NAME}-md-0"
-      clusterName: "${CLUSTER_NAME}"
       infrastructureRef:
         name: "${CLUSTER_NAME}-md-0"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: CloudStackMachineTemplate
-      version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: CloudStackMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
 spec:
   template:
     spec:
-      offering: 
+      offering:
         name: ${CLOUDSTACK_WORKER_MACHINE_OFFERING}
-      template: 
+      template:
         name: ${CLOUDSTACK_TEMPLATE_NAME}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -115,9 +118,8 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
+          name: '{{ local_hostname }}'
           kubeletExtraArgs:
             provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
-          name: '{{ local_hostname }}'
       preKubeadmCommands:
         - swapoff -a
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Ported templates to v1beta2.  Introduced use of env var defaulting in many cases.

*Testing performed:*
Successfully created a cluster using each template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->