### PR TITLE
makefile: Add cluster-templates to release-staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,7 @@ release-staging: ## Builds and push container images and manifests to the stagin
 	$(MAKE) docker-build
 	$(MAKE) docker-push
 	$(MAKE) release-alias-tag
+	$(MAKE) release-templates
 	$(MAKE) release-manifests TAG=$(RELEASE_ALIAS_TAG)
 	$(MAKE) upload-staging-artifacts
 


### PR DESCRIPTION
Uploads cluster-templates* with every staging release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->