### PR TITLE
Remove checking name when looking for a certain error message because…

### DIFF
--- a/test/e2e/invalid_resource.go
+++ b/test/e2e/invalid_resource.go
@@ -227,8 +227,7 @@ func errorExistsInLog(logFolder string, expectedError string) (bool, error) {
 			logLines := strings.Split(string(log), "\n")
 			for _, line := range logLines {
 				if strings.Contains(line, expectedError) &&
-					strings.Contains(line, clusterResources.Cluster.Namespace) &&
-					strings.Contains(line, clusterResources.Cluster.Name) {
+					strings.Contains(line, clusterResources.Cluster.Namespace) {
 					Byf("Found %q error", expectedError)
 					return expectedErrorFound
 				}

--- a/test/e2e/invalid_resource.go
+++ b/test/e2e/invalid_resource.go
@@ -212,7 +212,9 @@ func generateClusterName() string {
 
 // errorExistsInLog looks for a specific error message in the CAPC controller log files.  Because the logs may contain
 // entries from previous test runs, or from previous tests in the same run, the function also requires that the log
-// line contains the namespace and cluster names.
+// line contains the namespace. The cluster name is not check because some controllers such as failure domain controller
+// prints a different name which is not the cluster name. In the e2e testing, the namespace only is unique enough because
+// it is generated randomly per test case.
 func errorExistsInLog(logFolder string, expectedError string) (bool, error) {
 	expectedErrorFound := errors.New("expected error found")
 	controllerLogPath := filepath.Join(logFolder, "controllers", "capc-controller-manager")


### PR DESCRIPTION
… namespace is unique enough in e2e testing

*Issue #, if available:*
Three e2e test cases are failing
```
Should fail due to the specified domain is not found [TC4b] [It]
Should fail due to the specified account is not found [TC4a] [It]
Should fail due to the specified zone is not found [TC3] [It]
```

Looks like the name in the error log printed from failure domain controller is not something the test expect (cluster name). 
```
E0930 15:34:33.597419       1 controller.go:317] controller/cloudstackfailuredomain "msg"="Reconciler error" "error"="resolving account accountXXXX details: could not find account accountXXXX" "name"="470ad1cb9d240bf93ab6fc6586b0052c" "namespace"="invalid-resource-mqt4sb" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="CloudStackFailureDomain" 
```

*Description of changes:*
This PR removes checking the name field when looking for a certain error message because the namespace only is unique enough in e2e testing.


*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->