### PR TITLE
Use capi machine name as hostname and k8s node name

### DIFF
--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -41,6 +41,10 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
+var (
+	 hostnameMatcher = regexp.MustCompile(`\{\{\s*ds\.meta_data\.hostname\s*\}\}`)
+	 failuredomainMatcher = regexp.MustCompile(`\{\{\s*ds\.meta_data\.failuredomain\s*\}\}`)
+)
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=cloudstackmachines,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=cloudstackmachines/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=cloudstackmachines/finalizers,verbs=update
@@ -185,8 +189,6 @@ func processUserData(data []byte, r *CloudStackMachineReconciliationRunner) stri
 	// since cloudstack metadata does not allow custom data added into meta_data, following line is a hack to specify a hostname name
 	// {{ ds.meta_data.hostname }} is expected to be used as a name when kubelet register a node
 	// if more custom data needed to injected, this can be refactored into a method -- processCustomMetadata()
-	hostnameMatcher := regexp.MustCompile(`\{\{\s*ds\.meta_data\.hostname\s*\}\}`)
-	failuredomainMatcher := regexp.MustCompile(`\{\{\s*ds\.meta_data\.failuredomain\s*\}\}`)
 	userData := hostnameMatcher.ReplaceAllString(string(data), r.CAPIMachine.Name)
 	userData = failuredomainMatcher.ReplaceAllString(userData, r.FailureDomain.Spec.Name)
 	return userData

--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -42,9 +42,10 @@ import (
 )
 
 var (
-	 hostnameMatcher = regexp.MustCompile(`\{\{\s*ds\.meta_data\.hostname\s*\}\}`)
-	 failuredomainMatcher = regexp.MustCompile(`\{\{\s*ds\.meta_data\.failuredomain\s*\}\}`)
+	hostnameMatcher      = regexp.MustCompile(`\{\{\s*ds\.meta_data\.hostname\s*\}\}`)
+	failuredomainMatcher = regexp.MustCompile(`\{\{\s*ds\.meta_data\.failuredomain\s*\}\}`)
 )
+
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=cloudstackmachines,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=cloudstackmachines/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=cloudstackmachines/finalizers,verbs=update
@@ -186,7 +187,7 @@ func (r *CloudStackMachineReconciliationRunner) GetOrCreateVMInstance() (retRes 
 }
 
 func processUserData(data []byte, r *CloudStackMachineReconciliationRunner) string {
-	// since cloudstack metadata does not allow custom data added into meta_data, following line is a hack to specify a hostname name
+	// since cloudstack metadata does not allow custom data added into meta_data, following line is a walkaround to specify a hostname name
 	// {{ ds.meta_data.hostname }} is expected to be used as a name when kubelet register a node
 	// if more custom data needed to injected, this can be refactored into a method -- processCustomMetadata()
 	userData := hostnameMatcher.ReplaceAllString(string(data), r.CAPIMachine.Name)

--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
-	"strings"
+	"regexp"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -185,8 +185,10 @@ func processUserData(data []byte, r *CloudStackMachineReconciliationRunner) stri
 	// since cloudstack metadata does not allow custom data added into meta_data, following line is a hack to specify a hostname name
 	// {{ ds.meta_data.hostname }} is expected to be used as a name when kubelet register a node
 	// if more custom data needed to injected, this can be refactored into a method -- processCustomMetadata()
-	userData := strings.ReplaceAll(string(data), "{{ ds.meta_data.hostname }}", r.CAPIMachine.Name)
-	userData = strings.ReplaceAll(userData, "{{ds.meta_data.failuredomain}}", r.FailureDomain.Spec.Name)
+	hostnameMatcher := regexp.MustCompile(`\{\{\s*ds\.meta_data\.hostname\s*\}\}`)
+	failuredomainMatcher := regexp.MustCompile(`\{\{\s*ds\.meta_data\.failuredomain\s*\}\}`)
+	userData := hostnameMatcher.ReplaceAllString(string(data), r.CAPIMachine.Name)
+	userData = failuredomainMatcher.ReplaceAllString(userData, r.FailureDomain.Spec.Name)
 	return userData
 }
 

--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -187,7 +187,7 @@ func (r *CloudStackMachineReconciliationRunner) GetOrCreateVMInstance() (retRes 
 }
 
 func processUserData(data []byte, r *CloudStackMachineReconciliationRunner) string {
-	// since cloudstack metadata does not allow custom data added into meta_data, following line is a walkaround to specify a hostname name
+	// since cloudstack metadata does not allow custom data added into meta_data, following line is a workaround to specify a hostname name
 	// {{ ds.meta_data.hostname }} is expected to be used as a name when kubelet register a node
 	// if more custom data needed to injected, this can be refactored into a method -- processCustomMetadata()
 	userData := hostnameMatcher.ReplaceAllString(string(data), r.CAPIMachine.Name)

--- a/controllers/cloudstackmachine_controller_test.go
+++ b/controllers/cloudstackmachine_controller_test.go
@@ -73,7 +73,7 @@ var _ = Describe("CloudStackMachineReconciler", func() {
 			}, timeout).WithPolling(pollInterval).Should(BeTrue())
 		})
 
-		It("Should replace ds.mete_data.hostname with capi machine name.", func() {
+		It("Should replace ds.meta_data.hostname with capi machine name.", func() {
 			// Mock a call to GetOrCreateVMInstance and set the machine to running.
 			mockCloudClient.EXPECT().GetOrCreateVMInstance(
 				gomock.Any(), gomock.Any(), gomock.Any(),

--- a/controllers/cloudstackmachine_controller_test.go
+++ b/controllers/cloudstackmachine_controller_test.go
@@ -72,6 +72,32 @@ var _ = Describe("CloudStackMachineReconciler", func() {
 				return false
 			}, timeout).WithPolling(pollInterval).Should(BeTrue())
 		})
+
+		It("Should replace ds.mete_data.hostname with capi machine name.", func() {
+			// Mock a call to GetOrCreateVMInstance and set the machine to running.
+			mockCloudClient.EXPECT().GetOrCreateVMInstance(
+				gomock.Any(), gomock.Any(), gomock.Any(),
+				gomock.Any(), gomock.Any(), gomock.Any()).Do(
+				func(arg1, _, _, _, _, userdata interface{}) {
+					Ω(userdata == dummies.CAPIMachine.Name).Should(BeTrue())
+					arg1.(*infrav1.CloudStackMachine).Status.InstanceState = "Running"
+				}).AnyTimes()
+
+			// Have to do this here or the reconcile call to GetOrCreateVMInstance may happen too early.
+			setupMachineCRDs()
+
+			// Eventually the machine should set ready to true.
+			Eventually(func() bool {
+				tempMachine := &infrav1.CloudStackMachine{}
+				key := client.ObjectKey{Namespace: dummies.ClusterNameSpace, Name: dummies.CSMachine1.Name}
+				if err := k8sClient.Get(ctx, key, tempMachine); err == nil {
+					if tempMachine.Status.Ready == true {
+						return true
+					}
+				}
+				return false
+			}, timeout).WithPolling(pollInterval).Should(BeTrue())
+		})
 	})
 
 	Context("With a fake ctrlRuntimeClient and no test Env at all.", func() {

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -237,7 +237,7 @@ func (c *client) GetOrCreateVMInstance(
 	p := c.cs.VirtualMachine.NewDeployVirtualMachineParams(offeringID, templateID, fd.Spec.Zone.ID)
 	p.SetNetworkids([]string{fd.Spec.Zone.Network.ID})
 	setIfNotEmpty(csMachine.Name, p.SetName)
-	setIfNotEmpty(csMachine.Name, p.SetDisplayname)
+	setIfNotEmpty(capiMachine.Name, p.SetDisplayname)
 	setIfNotEmpty(diskOfferingID, p.SetDiskofferingid)
 	setIntIfPositive(csMachine.Spec.DiskOffering.CustomSize, p.SetSize)
 

--- a/pkg/cloud/instance_test.go
+++ b/pkg/cloud/instance_test.go
@@ -263,7 +263,12 @@ var _ = Describe("Instance", func() {
 					Return(&cloudstack.DeployVirtualMachineParams{})
 
 				deploymentResp := &cloudstack.DeployVirtualMachineResponse{Id: *dummies.CSMachine1.Spec.InstanceID}
-				vms.EXPECT().DeployVirtualMachine(gomock.Any()).Return(deploymentResp, nil)
+
+				vms.EXPECT().DeployVirtualMachine(gomock.Any()).Do(
+					func(p interface{}) {
+						displayName, _ := p.(*cloudstack.DeployVirtualMachineParams).GetDisplayname()
+						Ω(displayName == dummies.CAPIMachine.Name).Should(BeTrue())
+					}).Return(deploymentResp, nil)
 
 				Ω(client.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).

--- a/test/dummies/v1beta2/vars.go
+++ b/test/dummies/v1beta2/vars.go
@@ -364,11 +364,12 @@ func SetDummyIsoNetToNameOnly() {
 
 func SetDummyBootstrapSecretVar() {
 	BootstrapSecretName := "such-secret-much-wow"
+	BootstrapSecretValue := "{{ ds.meta_data.hostname }}"
 	BootstrapSecret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ClusterNameSpace,
 			Name:      BootstrapSecretName},
-		Data: map[string][]byte{"value": make([]byte, 0)}}
+		Data: map[string][]byte{"value": []byte(BootstrapSecretValue)}}
 }
 
 // Sets cluster spec to specified network.


### PR DESCRIPTION
*Issue #, if available:*
When kubernetes cluster is created using cloudstack, the CAPI machine name and k8s node name does not match
*Description of changes:*
Cloudstack metadata does not have a meta_data field named `hostname`, which can be used as hostname overwrite when VM is created in CloudStack platform. 

The fix is to inject `ds.meta_data.hostname` value using CAPI machine name in cloud-init user data, so CAPI machine name will be registered as a node name when kubelet does node registration.
*Testing performed:*
Manual testing.

```
➜  eks-main git:(main) ✗ k get machines -A
NAMESPACE     NAME                            CLUSTER   NODENAME                        PROVIDERID                                           PHASE     AGE   VERSION
eksa-system   wanyufe-etcd-lk4nb              wanyufe                                   cloudstack:///8132067e-a17c-4362-9f41-17ebde0a03bb   Running   23s   
eksa-system   wanyufe-g4ngn                   wanyufe   wanyufe-g4ngn                   cloudstack:///0118f9f5-b077-4ed6-8059-3a3bdf624bff   Running   23s   v1.21.13-eks-1-21-17
eksa-system   wanyufe-md-0-7cd6946f9d-6vxxb   wanyufe   wanyufe-md-0-7cd6946f9d-6vxxb   cloudstack:///163cd246-da31-4c03-8765-ab589d88218c   Running   23s   v1.21.13-eks-1-21-17
➜  eks-main git:(main) ✗ k get nodes 
NAME                            STATUS   ROLES                  AGE     VERSION
wanyufe-g4ngn                   Ready    control-plane,master   4m      v1.21.5-eks-1-21
wanyufe-md-0-7cd6946f9d-6vxxb   Ready    <none>                 2m43s   v1.21.5-eks-1-21
➜  eks-main git:(main) ✗ k get cloudstackmachines -A
NAMESPACE     NAME                                                 CLUSTER   INSTANCESTATE   READY   PROVIDERID                                           MACHINE
eksa-system   wanyufe-control-plane-template-1665026095159-4hh57   wanyufe   Running         true    cloudstack:///0118f9f5-b077-4ed6-8059-3a3bdf624bff   wanyufe-g4ngn
eksa-system   wanyufe-etcd-template-1665026095159-87khh            wanyufe   Running         true    cloudstack:///8132067e-a17c-4362-9f41-17ebde0a03bb   wanyufe-etcd-lk4nb
eksa-system   wanyufe-md-0-1665026095163-zlv87                     wanyufe   Running         true    cloudstack:///163cd246-da31-4c03-8765-ab589d88218c   wanyufe-md-0-7cd6946f9d-6vxxb
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->