### PR TITLE
Set owner reference to endpoint secret with the cluster if the secret…

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
@@ -170,6 +171,10 @@ func (m *MockCtrlrCloudClientImplementation) AsFailureDomainUser(
 
 func (m *MockCtrlrCloudClientImplementation) RegisterExtension(r *csCtrlrUtils.ReconciliationRunner) csCtrlrUtils.CloudClientExtension {
 	return &MockCtrlrCloudClientImplementation{ReconciliationRunner: r}
+}
+
+func (m *MockCtrlrCloudClientImplementation) GetSecretForFailureDomain(fdSpec *infrav1.CloudStackFailureDomainSpec) (*corev1.Secret, error) {
+	return dummies.ACSEndpointSecret1, nil
 }
 
 func SetupTestEnvironment() {


### PR DESCRIPTION
*Issue #, if available:* #172

*Description of changes:*
When a secret is dedicated to a cluster by labeling the secret with the cluster name and it's not already owned by a cluster CAPC sets the secret's owner reference with the target cluster. 

*Testing performed:*
TBD

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->