### PR TITLE
Added least privilege role description to docs (book).

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -9,6 +9,7 @@
     - [Custom Images](topics/custom-images.md)
     - [SSH Access To Nodes](topics/ssh-access.md)
     - [Unstacked etcd](topics/unstacked-etcd.md)
+    - [CloudStack Permissions](topics/cloudstack-permissions.md)
 - [Developer Guide](development/index.md)
     - [Development With Tilt](development/tilt.md)
     - [Building CAPC](development/building.md)

--- a/docs/book/src/topics/cloudstack-permissions.md
+++ b/docs/book/src/topics/cloudstack-permissions.md
@@ -1,0 +1,42 @@
+# CloudStack Permissions for CAPC
+
+The account that CAPC runs under must minimally be a Domain Admin type account with a role offering the following permissions
+
+* assignToLoadBalancerRule
+* associateIpAddress
+* createAffinityGroup
+* createEgressFirewallRule
+* createLoadBalancerRule
+* createNetwork
+* createTags
+* deleteAffinityGroup
+* deleteNetwork
+* deleteTags
+* deployVirtualMachine
+* destroyVirtualMachine
+* disassociateIpAddress
+* getUserKeys
+* listAccounts
+* listAffinityGroups
+* listDiskOfferings
+* listDomains
+* listLoadBalancerRuleInstances
+* listLoadBalancerRules
+* listNetworkOfferings
+* listNetworks
+* listPublicIpAddresses
+* listServiceOfferings
+* listSSHKeyPairs
+* listTags
+* listTemplates
+* listUsers
+* listVirtualMachines
+* listVirtualMachinesMetrics
+* listVolumes
+* listZones
+* queryAsyncJobResult
+* startVirtualMachine
+* stopVirtualMachine
+* updateVMAffinityGroup
+
+This permission set has been verified to successfully run the CAPC E2E test suite.

--- a/docs/book/src/topics/cloudstack-permissions.md
+++ b/docs/book/src/topics/cloudstack-permissions.md
@@ -39,4 +39,4 @@ The account that CAPC runs under must minimally be a Domain Admin type account w
 * stopVirtualMachine
 * updateVMAffinityGroup
 
-This permission set has been verified to successfully run the CAPC E2E test suite (Nov 11, 2022).
+This permission set has been verified to successfully run the CAPC E2E test suite (Oct 11, 2022).

--- a/docs/book/src/topics/cloudstack-permissions.md
+++ b/docs/book/src/topics/cloudstack-permissions.md
@@ -39,4 +39,4 @@ The account that CAPC runs under must minimally be a Domain Admin type account w
 * stopVirtualMachine
 * updateVMAffinityGroup
 
-This permission set has been verified to successfully run the CAPC E2E test suite.
+This permission set has been verified to successfully run the CAPC E2E test suite (Nov 11, 2022).

--- a/docs/book/src/topics/index.md
+++ b/docs/book/src/topics/index.md
@@ -5,6 +5,7 @@
 - [Custom Images](custom-images.md)
 - [SSH Access To Nodes](ssh-access.md)
 - [Unstacked etcd](unstacked-etcd.md)
+- [CloudStack Permissions](cloudstack-permissions.md)
 
 
 ## TODO :


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Book changes: new page describing least-privilege ACS role required to successfully run CAPC

*Testing performed:*
Ran e2e tests against ACS DomainAdmin type accounts having a role with the documented privileges (rules).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->