### PR TITLE
Making ObjectMeta in CloudStackMachineTemplateResource nullable

### DIFF
--- a/api/v1beta2/cloudstackmachinetemplate_types.go
+++ b/api/v1beta2/cloudstackmachinetemplate_types.go
@@ -24,6 +24,7 @@ type CloudStackMachineTemplateResource struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
+	// +nullable
 	ObjectMeta metav1.ObjectMeta     `json:"metadata,omitempty"`
 	Spec       CloudStackMachineSpec `json:"spec"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_cloudstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_cloudstackmachinetemplates.yaml
@@ -240,6 +240,7 @@ spec:
                 properties:
                   metadata:
                     description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    nullable: true
                     type: object
                   spec:
                     description: CloudStackMachineSpec defines the desired state of


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We have a usecase in EKS-A where we serialize a Go object, then apply it to the cluster. When we try to do this with a CloudStackMachineTemplate, the resulting object looks like
```
apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
kind: CloudStackMachineTemplate
metadata:
  creationTimestamp: null
  name: drib-upgrade-control-plane-template-1665592860423
  namespace: eksa-system
spec:
  template:
    metadata:
      creationTimestamp: null
    spec:
      diskOffering:
        customSizeInGB: 0
        device: ""
        filesystem: ""
        label: ""
        mountPath: ""
      offering:
        name: Large Instance
      sshKey: ""
      template:
        name: rhel-8-kube-v1.21.5-new
```

and when it gets applied, we observe a validation error from the kube-api server:
```
unknown object type "nil" in CloudStackMachineTemplate.spec.template.metadata.creationTimestamp; if you choose to ignore these errors, turn validation off with --validate=false
```

Given that this objectmeta is unused in the CAPC codebase, instead of removing it, I think we should make it nullable for backwards compatibility.

*Testing performed:*
Generated new CAPC infrastructure-components and created cluster with them. Applied the serialized CloudStackMachineTemplate above and it succeeded without validation errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->