### PR TITLE
Fixing broken build on linux due to inline comment

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -17,7 +17,8 @@ include $(REPO_ROOT)/versions.mk
 # Ensure Make is run with bash shell as some syntax below is bash-specific
 SHELL:=bash
 .ONESHELL:
-.SHELLFLAGS := -euc # No spaces allowed in linux SHELLFLAGS, so omitting -o pipefail
+# No spaces allowed in linux SHELLFLAGS, so omitting -o pipefail
+.SHELLFLAGS := -euc
 .DELETE_ON_ERROR:
 MAKEFLAGS += --no-builtin-rules
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Inline commented resulted in the same error as in https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/pull/177 when building on linux due to spaces being parsed incorrectly.

*Testing performed:*
Moved the comment and built properly on linux. Copied the raw file contents of common.mk to make sure it worked.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->