### PR TITLE
update regexp for ds.meta_data.failuredomain replacement

### DIFF
--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -43,7 +43,7 @@ import (
 
 var (
 	hostnameMatcher      = regexp.MustCompile(`\{\{\s*ds\.meta_data\.hostname\s*\}\}`)
-	failuredomainMatcher = regexp.MustCompile(`\{\{\s*ds\.meta_data\.failuredomain\s*\}\}`)
+	failuredomainMatcher = regexp.MustCompile(`ds\.meta_data\.failuredomain`)
 )
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=cloudstackmachines,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/cloudstackmachine_controller_test.go
+++ b/controllers/cloudstackmachine_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers_test
 
 import (
+	"fmt"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -73,13 +74,14 @@ var _ = Describe("CloudStackMachineReconciler", func() {
 			}, timeout).WithPolling(pollInterval).Should(BeTrue())
 		})
 
-		It("Should replace ds.meta_data.hostname with capi machine name.", func() {
+		It("Should replace ds.meta_data.xxx with proper values.", func() {
 			// Mock a call to GetOrCreateVMInstance and set the machine to running.
 			mockCloudClient.EXPECT().GetOrCreateVMInstance(
 				gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any(), gomock.Any(), gomock.Any()).Do(
 				func(arg1, _, _, _, _, userdata interface{}) {
-					Ω(userdata == dummies.CAPIMachine.Name).Should(BeTrue())
+					expectedUserdata := fmt.Sprintf("%s{{%s}}", dummies.CAPIMachine.Name, dummies.CSMachine1.Spec.FailureDomainName)
+					Ω(userdata == expectedUserdata).Should(BeTrue())
 					arg1.(*infrav1.CloudStackMachine).Status.InstanceState = "Running"
 				}).AnyTimes()
 

--- a/test/dummies/v1beta2/vars.go
+++ b/test/dummies/v1beta2/vars.go
@@ -227,8 +227,9 @@ func SetDummyCSMachineVars() {
 			Labels:    ClusterLabel,
 		},
 		Spec: infrav1.CloudStackMachineSpec{
-			Name:       "test-machine-1",
-			InstanceID: pointer.String("Instance1"),
+			Name:              "test-machine-1",
+			InstanceID:        pointer.String("Instance1"),
+			FailureDomainName: GetYamlVal("CLOUDSTACK_FD1_NAME"),
 			Template: infrav1.CloudStackResourceIdentifier{
 				Name: GetYamlVal("CLOUDSTACK_TEMPLATE_NAME"),
 			},
@@ -398,7 +399,7 @@ func SetDummyIsoNetToNameOnly() {
 
 func SetDummyBootstrapSecretVar() {
 	BootstrapSecretName := "such-secret-much-wow"
-	BootstrapSecretValue := "{{ ds.meta_data.hostname }}"
+	BootstrapSecretValue := "{{ ds.meta_data.hostname }}{{ds.meta_data.failuredomain}}"
 	BootstrapSecret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ClusterNameSpace,


### PR DESCRIPTION
*Issue #, if available:*
To support node label to specify failure domain for k8s nodes.
*Description of changes:*
Before passing user-data (generated by eks-a or others) to cloudstack API, ds.meta_data.failuredomain is replaced with CAPI failuredomains. Cloudstack meta data provider does not have the concept of CAPI failuredomain.
*Testing performed:*
unit testing, Manual testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->