### PR TITLE
Release v0.4.8 artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ release-manifests: $(RELEASE_MANIFEST_TARGETS) ## Create kustomized release mani
 $(RELEASE_DIR)/%: $(RELEASE_MANIFEST_INPUTS)
 	@mkdir -p $(RELEASE_DIR)
 	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
-	$(KUSTOMIZE) build config/default > $(RELEASE_DIR)/infrastructure-components.yaml
+	$(KUSTOMIZE) build $(RELEASE_MANIFEST_SOURCE_BASE) > $(RELEASE_DIR)/infrastructure-components.yaml
 
 .PHONY: release-manifests-metrics-port
 release-manifests-metrics-port:

--- a/releases/v0.4.8/RELEASE_NOTES.md
+++ b/releases/v0.4.8/RELEASE_NOTES.md
@@ -1,0 +1,39 @@
+# Cluster API Provider for Cloudstack (CAPC) Release Notes
+
+## Version v0.4.8
+
+These Release Notes are for the customer downloading and deploying CAPC private Version 0.4.8 released on 10/20/2022.
+
+### This release extends the v0.4.4 release of CAPC with:
+  * Support for distributing VMs across multiple CloudStack management endpoints via Failure Domains (in addition to pre-existing Zone, Domain and Account-based Failure Domains)
+  * v1beta2 declared, as the above is a breaking change.
+  * Switch to user-provisioned-secret-based CloudStack credentials (from the previous env-var-based method).
+  * Support for Customized Disk Offerings (i.e., with parameters)
+  * Custom metrics that count CloudStack API errors returned, grouped by error code.
+  * new *make* target and config files for creating an alternative infrastructure-components.yaml that exposes the manager metrics port from the pod via kube-rbac-proxy.
+  * Discontinued MachineStateChecker, as the remediation technique of deleting CAPI machines from with the manager is proving unreliable.
+  * Use of CAPI Machine name as hostname and k8s node name
+  * Various bug fixes, doc improvements and build/test enhancements.
+
+### TLS Certificates
+The default mode of operation for the deployed Kubernetes cluster components is to use self-signed certificates.  Options exist for use of an enterprise certificate authority via cert-manager (https://cert-manager.io/docs/configuration/).  Detailed configuration of this component is outside the scope of this release.
+
+### Pre-conditions
+
+* The following pre-conditions must be met for CAPC to operate as designed.
+    * A functional CloudStack 4.14 or 4.16 deployment
+    * The CloudStack account used by CAPC must have domain administrator privileges or be otherwise appropriately privileged to execute the API calls specified in the below CAPC CloudStack API Calls document link.  A least-privilege CloudStack Role is now documents in the CAPC book. 
+    * Zone(s) and Network(s) must be pre-created and available to CAPC prior to CreateCluster API call.
+    * A VM template suitable for implementing a Kubernetes node with kubeadm must be available in CloudStack.
+        * The software has been tested with RHEL-8 images created with CAPI Image-builder.
+        * Links to pre-built images are available in the CAPC Book.
+    * Machine offerings suitable for running Kubernetes nodes must be available in CloudStack
+    * When using CloudStack Shared Networks, an unused IP address in the shared network’s address range must be available for the Kubernetes Control Plane for each cluster, upon which it will be exposed.
+
+### Release Assets :
+* CAPI Standard deployment manifests: infrastructure-components.yaml, metadata.yaml, cluster-template.yaml and its flavor variations.
+* capi-cloudstack-controller image, at gcr.io/k8s-staging-capi-cloudstack
+* security_findings.csv: results of package security scan
+
+### Known Issues :
+* Cluster upgrade is not supported when the controlPlaneEndpoint is defined to be an IP address in a shared network when not using kube-vip for the control plane. 

--- a/releases/v0.4.8/security_findings.csv
+++ b/releases/v0.4.8/security_findings.csv
@@ -1,0 +1,21 @@
+﻿Component,Vulnerability IDs,
+cloud.google.com/go/storage:1.10.0,cpe:2.3:a:storage_project:storage:1.10.0:*:*:*:*:*:*:*,No exploitable issue. This finding only affects applications unpacking container Image manifests.
+github.com/coreos/etcd:3.3.13+incompatible,cpe:2.3:a:etcd:etcd:3.3.13:*:*:*:*:*:*:*,"No exploitable issue. etcd is unused in Kubernetes CAPI controllers, only the Kubernetes API server interacts with an etcd database."
+github.com/docker/distribution:2.7.1+incompatible,cpe:2.3:a:docker:docker:2.7.1:*:*:*:*:*:*:*,No exploitable issue. The Docker API and client are unused in a Kubernetes CAPI controller.
+github.com/emicklei/go-restful:2.9.5+incompatible,cpe:2.3:a:go-restful_project:go-restful:2.9.5:*:*:*:*:*:*:*,Used by Kubernetes libraries (i.e. k8s.io/apiserver). As of 2022-10-20 NIST reports that the vulnerability is undergoing re-analysis with recommendation to check-back.
+github.com/grpc-ecosystem/go-grpc-middleware:1.3.0,cpe:2.3:a:grpc:grpc:1.3.0:*:*:*:*:*:*:*,No exploitable issue. Kubernetes controllers do not make or issue gRPC calls.
+github.com/grpc-ecosystem/go-grpc-prometheus:1.2.0,cpe:2.3:a:grpc:grpc:1.2.0:*:*:*:*:*:*:*,No exploitable issue. Kubernetes controllers do not make or issue gRPC calls.
+github.com/grpc-ecosystem/grpc-gateway:1.16.0,cpe:2.3:a:grpc:grpc:1.16.0:*:*:*:*:*:*:*,No exploitable issue. Kubernetes controllers do not make or issue gRPC calls.
+github.com/hashicorp/consul/api:1.10.1,cpe:2.3:a:hashicorp:consul:1.10.1:*:*:*:*:*:*:*,No exploitable issue. Consul is unused by a Kubernetes CAPI controller.
+github.com/hashicorp/consul/sdk:0.8.0,cpe:2.3:a:hashicorp:consul:0.8.0:*:*:*:*:*:*:*,No exploitable issue. Consul is unused by a Kubernetes CAPI controller.
+github.com/matttproud/golang_protobuf_extensions:1.0.2-0.20181231171920-c182affec369,cpe:2.3:a:golang:protobuf:1.0.2.0.20181231171920.c182.fec369:*:*:*:*:*:*:*,No exploitable issue. Kubernetes controllers do not make or issue gRPC calls.
+github.com/prometheus/client_golang:1.11.0,cpe:2.3:a:prometheus:client_golang:1.11.0:*:*:*:*:*:*:*,No exploitable issue. The mentioned vulnerability is related to the Prometheus UI.
+github.com/prometheus/client_model:0.2.0,cpe:2.3:a:prometheus:prometheus:0.2.0:*:*:*:*:*:*:*,No exploitable issue. The mentioned vulnerability is related to the Prometheus UI.
+github.com/prometheus/common:0.26.0,cpe:2.3:a:prometheus:prometheus:0.26.0:*:*:*:*:*:*:*,No exploitable issue. The mentioned vulnerability is related to the Prometheus UI.
+github.com/prometheus/procfs:0.6.0,cpe:2.3:a:prometheus:prometheus:0.6.0:*:*:*:*:*:*:*,No exploitable issue. The mentioned vulnerability is related to the Prometheus UI.
+github.com/prometheus/tsdb:0.7.1,cpe:2.3:a:prometheus:prometheus:0.7.1:*:*:*:*:*:*:*,No exploitable issue. The mentioned vulnerability is related to the Prometheus UI.
+github.com/tmc/grpc-websocket-proxy:0.0.0-20201229170055-e5319fda7802,cpe:2.3:a:grpc:grpc:0.0.0.20201229170055.e5319.fda7802:*:*:*:*:*:*:*,No exploitable issue. Kubernetes controllers do not make or issue gRPC calls.
+go.etcd.io/etcd/client/v2:2.305.0,cpe:2.3:a:etcd:etcd:2.305.0:*:*:*:*:*:*:*,"No exploitable issue. etcd is unused in Kubernetes CAPI controllers, only the Kubernetes API server interacts with an etcd database."
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc:0.20.0,cpe:2.3:a:grpc:grpc:0.20.0:*:*:*:*:*:*:*,No exploitable issue. Kubernetes controllers do not make or issue gRPC calls.
+google.golang.org/grpc/cmd/protoc-gen-go-grpc:1.1.0,cpe:2.3:a:grpc:grpc:1.1.0:*:*:*:*:*:*:*,No exploitable issue. Kubernetes controllers do not make or issue gRPC calls.
+gopkg.in/yaml.v3:3.0.0-20210107192922-496545a6307b,cpe:2.3:a:yaml_project:yaml:3.0.0:*:*:*:*:go:*:*,As of 2022-10-20 NIST reports that the vulnerability is undergoing re-analysis with recommendation to check-back.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Created release docs for v0.4.8
Fixed bug introduced in Makefile that prevented correct generation of make target release-manifests-metrics-port.

*Testing performed:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->