### PR TITLE
Fix Makefile to run e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ run: generate-deepcopy generate-conversion ## Run a controller from your host.
 
 .PHONY: deploy
 deploy: generate-deepcopy generate-manifests $(KUSTOMIZE) ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(REPO_ROOT)/$(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	cd $(REPO_ROOT)
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ endif
 export ACK_GINKGO_DEPRECATIONS := 1.16.5
 export ACK_GINKGO_RC=true
 
-export PATH := $(REPO_ROOT)/$(TOOLS_BIN_DIR):$(PATH)
+export PATH := $(TOOLS_BIN_DIR):$(PATH)
 
 all: build
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Running e2e test fails with the following error. 
```
      failed to execute kustomize: : exec: "kustomize": executable file not found in $PATH
```

*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->