### PR TITLE
Multi vm affinity e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,12 +280,13 @@ e2e-essentials: $(GINKGO_V1) $(KUBECTL) e2e-cluster-templates kind-cluster ## Fu
 	IMG=$(IMG_LOCAL) make generate-manifests docker-build docker-push
 
 JOB ?= .*
+E2E_CONFIG ?= ${REPO_ROOT}/test/e2e/config/cloudstack.yaml
 run-e2e: e2e-essentials ## Run e2e testing. JOB is an optional REGEXP to select certainn test cases to run. e.g. JOB=PR-Blocking, JOB=Conformance
 	$(KUBECTL) apply -f cloud-config.yaml && \
 	cd test/e2e && \
 	$(GINKGO_V1) -v -trace -tags=e2e -focus=$(JOB) -skip=Conformance -skipPackage=helpers -nodes=1 -noColor=false ./... -- \
 	    -e2e.artifacts-folder=${REPO_ROOT}/_artifacts \
-	    -e2e.config=${REPO_ROOT}/test/e2e/config/cloudstack.yaml \
+	    -e2e.config=${E2E_CONFIG} \
 	    -e2e.skip-resource-cleanup=false -e2e.use-existing-cluster=true
 	kind delete clusters capi-test
 

--- a/test/e2e/affinity_group.go
+++ b/test/e2e/affinity_group.go
@@ -79,6 +79,17 @@ func AffinityGroupSpec(ctx context.Context, inputGetter func() CommonSpecInput) 
 }
 
 func executeTest(ctx context.Context, input CommonSpecInput, namespace *corev1.Namespace, specName string, clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult, affinityType string) []string {
+	csClient := CreateCloudStackClient(ctx, input.BootstrapClusterProxy.GetKubeconfigPath())
+	zoneName := input.E2EConfig.GetVariable("CLOUDSTACK_ZONE_NAME")
+	numHosts := GetHostCount(csClient, zoneName)
+	machineCount := int64(3) // Must allocate an odd number of CP machines w/ stacked etcd
+	if numHosts < 3 {
+		// If not enough ACS hosts to support 3 machines with anti-affinity, fall back to just allocating one machine.
+		//  Test will only confirm that the single VM is in an anti-affinity group, but not that ACS anti-affinty works.
+		By("Fewer than three host in ACS env.  Only verifying that a single VM gets placed in an AG, not that true affinity/anti-affinity is ultimately achieved.")
+		machineCount = int64(1)
+	}
+
 	clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 		ClusterProxy:    input.BootstrapClusterProxy,
 		CNIManifestPath: input.E2EConfig.GetVariable(CNIPath),
@@ -91,14 +102,13 @@ func executeTest(ctx context.Context, input CommonSpecInput, namespace *corev1.N
 			Namespace:                namespace.Name,
 			ClusterName:              fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
 			KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),
-			ControlPlaneMachineCount: pointer.Int64Ptr(1),
-			WorkerMachineCount:       pointer.Int64Ptr(1),
+			ControlPlaneMachineCount: pointer.Int64Ptr(int64(machineCount)),
+			WorkerMachineCount:       pointer.Int64Ptr(machineCount),
 		},
 		WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
 		WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
 		WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 	}, clusterResources)
 
-	csClient := CreateCloudStackClient(ctx, input.BootstrapClusterProxy.GetKubeconfigPath())
 	return CheckAffinityGroup(csClient, clusterResources.Cluster.Name, affinityType)
 }

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -287,6 +287,24 @@ func CheckAffinityGroupsDeleted(client *cloudstack.CloudStackClient, affinityIds
 	return nil
 }
 
+func GetHostCount(client *cloudstack.CloudStackClient, zoneName string) int {
+	pz := client.Zone.NewListZonesParams()
+	pz.SetName(zoneName)
+	listZonesResponse, err := client.Zone.ListZones(pz)
+	Expect(err).To(BeNil(), "error listing zones")
+	Expect(listZonesResponse.Count).To(Equal(1), "multiple zones resolve to zone name %s", zoneName)
+	zoneId := listZonesResponse.Zones[0].Id
+
+	ph := client.Host.NewListHostsParams()
+	ph.SetZoneid(zoneId)
+	ph.SetHypervisor("KVM")
+	ph.SetResourcestate("Enabled")
+	ph.SetState("Up")
+	listHostsResponse, err := client.Host.ListHosts(ph)
+	Expect(err).To(BeNil(), "error listing hosts")
+	return listHostsResponse.Count
+}
+
 func CheckAffinityGroup(client *cloudstack.CloudStackClient, clusterName string, affinityType string) []string {
 	By("Listing all machines")
 	p := client.VirtualMachine.NewListVirtualMachinesParams()

--- a/test/e2e/config/cloudstack-10-11-0-2.yaml
+++ b/test/e2e/config/cloudstack-10-11-0-2.yaml
@@ -1,0 +1,174 @@
+---
+# E2E test scenario using local dev images and manifests built from the source tree for following providers:
+# - cluster-api
+# - bootstrap kubeadm
+# - control-plane kubeadm
+# - cloudstack
+
+managementClusterName: capi-test
+
+images:
+  # Use local dev images built source tree;
+  - name: localhost:5000/cluster-api-provider-cloudstack:latest
+    loadBehavior: mustLoad
+
+  ## PLEASE KEEP THESE UP TO DATE WITH THE COMPONENTS
+
+  # Cluster API v1beta1 Preloads
+  - name: gcr.io/k8s-staging-cluster-api/cluster-api-controller-amd64:v1.0.0
+    loadBehavior: tryLoad
+  - name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller-amd64:v1.0.0
+    loadBehavior: tryLoad
+  - name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller-amd64:v1.0.0
+    loadBehavior: tryLoad
+  - name: gcr.io/k8s-staging-cluster-api/capd-manager-amd64:v1.0.0
+    loadBehavior: tryLoad
+  - name: quay.io/jetstack/cert-manager-cainjector:v1.5.3
+    loadBehavior: tryLoad
+  - name: quay.io/jetstack/cert-manager-webhook:v1.5.3
+    loadBehavior: tryLoad
+  - name: quay.io/jetstack/cert-manager-controller:v1.5.3
+    loadBehavior: tryLoad
+
+providers:
+  - name: cluster-api
+    type: CoreProvider
+    versions:
+      - name: v1.0.0
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/core-components.yaml"
+        type: "url"
+        contract: v1beta1
+        replacements:
+        - old: --metrics-addr=127.0.0.1:8080
+          new: --metrics-addr=:8080
+        files:
+        - sourcePath: "../data/shared/v1beta1/metadata.yaml"
+
+  - name: kubeadm
+    type: BootstrapProvider
+    versions:
+      - name: v1.0.0
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/bootstrap-components.yaml"
+        type: "url"
+        contract: v1beta1
+        replacements:
+        - old: --metrics-addr=127.0.0.1:8080
+          new: --metrics-addr=:8080
+        files:
+        - sourcePath: "../data/shared/v1beta1/metadata.yaml"
+
+  - name: kubeadm
+    type: ControlPlaneProvider
+    versions:
+      - name: v1.0.0
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/control-plane-components.yaml"
+        type: "url"
+        contract: v1beta1
+        replacements:
+        - old: --metrics-addr=127.0.0.1:8080
+          new: --metrics-addr=:8080
+        files:
+        - sourcePath: "../data/shared/v1beta1/metadata.yaml"
+
+  - name: cloudstack
+    type: InfrastructureProvider
+    files:
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-zone.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-account.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-domain.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-template.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-cp-offering.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-insufficient-compute-resources.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-insufficient-compute-resources-for-upgrade.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-node-drain.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-machine-remediation.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-affinity-group-pro.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-affinity-group-anti.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-resource-cleanup.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-second-cluster.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-shared-network-kubevip.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-disk-offering.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-disk-offering-size-for-non-customized.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-disk-offering-size-for-customized.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-disk-offering.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-custom-disk-offering.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-subdomain.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-ip.yaml"
+      - sourcePath: "../data/shared/v1beta1/metadata.yaml"
+    versions:
+      - name: v1.0.0
+        value: ../../../config/default
+        contract: v1beta1
+        replacements:
+          - old: --metrics-bind-addr=localhost:8080
+            new: --metrics-bind-addr=:8080
+          - old: "--leader-elect"
+            new: "--leader-elect\n        - --metrics-bind-addr=:8080"
+
+variables:
+  KUBERNETES_VERSION_MANAGEMENT: "v1.20.10"
+  KUBERNETES_VERSION: "v1.20.10"
+  CNI: "./data/cni/kindnet.yaml"
+  IP_FAMILY: "IPv4"
+  NODE_DRAIN_TIMEOUT: "60s"
+
+  CLOUDSTACK_FD1_NAME: "fd1"
+  CLOUDSTACK_FD1_SECRET_NAME: "secret1"
+  CLOUDSTACK_FD1_SECRET_NAMESPACE: "default"
+  CLOUDSTACK_ZONE_NAME: Zone2
+  CLOUDSTACK_INVALID_ZONE_NAME: zoneXXXX
+  CLOUDSTACK_INVALID_NETWORK_NAME: networkXXXX
+  CLOUDSTACK_ACCOUNT_NAME: admin
+  CLOUDSTACK_INVALID_ACCOUNT_NAME: accountXXXX
+  CLOUDSTACK_DOMAIN_NAME: ROOT
+  CLOUDSTACK_INVALID_DOMAIN_NAME: domainXXXX
+  CLOUDSTACK_NETWORK_NAME: isolated-for-e2e-1
+  CLOUDSTACK_NEW_NETWORK_NAME: isolated-for-e2e-new
+  CLOUDSTACK_SHARED_NETWORK_NAME: SharedNet2
+  CLUSTER_ENDPOINT_IP: 10.11.3.98
+  CLUSTER_ENDPOINT_IP_2: 10.11.3.97
+  CLOUDSTACK_INVALID_IP: 1.2.3.4
+  CLOUDSTACK_CONTROL_PLANE_MACHINE_OFFERING: "Fruitstand Instance"
+  CLOUDSTACK_INVALID_CONTROL_PLANE_MACHINE_OFFERING: "OfferingXXXX"
+  CLOUDSTACK_IMPOSSIBLE_CONTROL_PLANE_MACHINE_OFFERING: "Impossible Instance"
+  CLOUDSTACK_WORKER_MACHINE_OFFERING: "Medium Instance"
+  CLOUDSTACK_IMPOSSIBLE_WORKER_MACHINE_OFFERING: "Impossible Instance"
+  CLOUDSTACK_TEMPLATE_NAME: ubuntu-2004-kube-v1.20.10
+  CLOUDSTACK_INVALID_TEMPLATE_NAME: templateXXXX
+  CLOUDSTACK_SSH_KEY_NAME: CAPCKeyPair6
+
+  CLOUDSTACK_INVALID_DISK_OFFERING_NAME: diskOfferingXXXX
+  CLOUDSTACK_DISK_OFFERING_NAME: Small
+  CLOUDSTACK_CUSTOM_DISK_OFFERING_NAME: Custom
+  CLOUDSTACK_DISK_OFFERING_CUSTOM_SIZE: 1
+  CLOUDSTACK_DISK_OFFERING_DEVICE: /dev/vdc
+  CLOUDSTACK_DISK_OFFERING_FILESYSTEM: ext4
+  CLOUDSTACK_DISK_OFFERING_LABEL: my_disk
+  CLOUDSTACK_DISK_OFFERING_MOUNT_PATH: /my_disk
+
+  CLOUDSTACK_SUBDOMAIN_PATH: SUBDOMAIN
+  CLOUDSTACK_SUBDOMAIN_ACCOUNT_NAME:	SUBDOMAIN-ADMIN
+
+  CONFORMANCE_CONFIGURATION: "./data/kubetest/conformance.yaml"
+  CONFORMANCE_WORKER_MACHINE_COUNT: "3"
+  CONFORMANCE_CONTROL_PLANE_MACHINE_COUNT: "1"
+
+intervals:
+  conformance/wait-control-plane: ["20m", "10s"]
+  conformance/wait-worker-nodes: ["20m", "10s"]
+
+  default/wait-errors: ["5m", "10s"]
+  default/wait-controllers: ["3m", "10s"]
+  default/wait-cluster: ["5m", "10s"]
+  default/wait-control-plane: ["20m", "10s"]
+  default/wait-worker-nodes: ["20m", "10s"]
+  default/wait-delete-cluster: ["20m", "10s"]
+  default/wait-machine-remediation: ["20m", "10s"]
+  default/wait-machine-upgrade: ["20m", "10s"]
+
+  node-drain/wait-deployment-available: ["3m", "10s"]
+  node-drain/wait-control-plane: ["15m", "10s"]
+  node-drain/wait-machine-deleted: ["5m", "10s"]
+
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changes to E2E affinity tests to support true affinity testing if ACS env has three or more hosts in the zone being used for the test.  If fewer than three hosts are available, falls back to the pre-existing one-VM test, which only verifies that the VM is placed in the appropriate affinity group.

*Testing performed:*
Executed test in single host and 3-host environments, observing it allocating the one or three VMs respectively for the CP and workers.  Tests pass in both cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->