### PR TITLE
add events to cloudstack machine resource

### DIFF
--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -187,7 +187,7 @@ func (r *CloudStackMachineReconciliationRunner) DeleteMachineIfFailuredomainNotE
 // Implicitly it also fetches its bootstrap secret in order to create said instance.
 func (r *CloudStackMachineReconciliationRunner) GetOrCreateVMInstance() (retRes ctrl.Result, reterr error) {
 	if r.CAPIMachine.Spec.Bootstrap.DataSecretName == nil {
-		r.Recorder.Event(r.ReconciliationSubject, "Normal", "Creating", "Bootstrap DataSecretName not yet available.")
+		r.Recorder.Event(r.ReconciliationSubject, "Normal", "Creating", "Bootstrap DataSecretName not yet available")
 		return r.RequeueWithMessage("Bootstrap DataSecretName not yet available.")
 	}
 	r.Log.Info("Got Bootstrap DataSecretName.")
@@ -233,14 +233,14 @@ func (r *CloudStackMachineReconciliationRunner) RequeueIfInstanceNotRunning() (r
 		r.Log.Info("Machine instance is Running...")
 		r.ReconciliationSubject.Status.Ready = true
 	} else if r.ReconciliationSubject.Status.InstanceState == "Error" {
-		r.Recorder.Event(r.ReconciliationSubject, "Warning", "Error", "CloudStackMachine VM in error state. Deleting associated Machine.")
+		r.Recorder.Event(r.ReconciliationSubject, "Warning", "Error", "CloudStackMachine VM in error state. Deleting associated Machine")
 		r.Log.Info("CloudStackMachine VM in error state. Deleting associated Machine.", "csMachine", r.ReconciliationSubject.GetName())
 		if err := r.K8sClient.Delete(r.RequestCtx, r.CAPIMachine); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: utils.RequeueTimeout}, nil
 	} else {
-		r.Recorder.Eventf(r.ReconciliationSubject, "Warning", r.ReconciliationSubject.Status.InstanceState, "Instance not ready, is %s.", r.ReconciliationSubject.Status.InstanceState)
+		r.Recorder.Eventf(r.ReconciliationSubject, "Warning", r.ReconciliationSubject.Status.InstanceState, "Instance not ready, is %s", r.ReconciliationSubject.Status.InstanceState)
 		r.Log.Info(fmt.Sprintf("Instance not ready, is %s.", r.ReconciliationSubject.Status.InstanceState))
 		return ctrl.Result{RequeueAfter: utils.RequeueTimeout}, nil
 	}

--- a/controllers/cloudstackmachine_controller_test.go
+++ b/controllers/cloudstackmachine_controller_test.go
@@ -252,12 +252,12 @@ var _ = Describe("CloudStackMachineReconciler", func() {
 			res, err := MachineReconciler.Reconcile(ctx, ctrl.Request{NamespacedName: requestNamespacedName})
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(res.RequeueAfter).Should(BeZero())
-			
+
 			Eventually(func() bool {
 				for event := range fakeRecorder.Events {
 					return strings.Contains(event, "Normal Created CloudStack instance Created") ||
 						strings.Contains(event, "Normal Running Machine instance is Running...") ||
-						strings.Contains(event, "Normal Machine State Checker CloudStackMachineStateChecker Instance1 created")
+						strings.Contains(event, "Normal Machine State Checker CloudStackMachineStateChecker created")
 				}
 				return false
 			}, timeout).Should(BeTrue())

--- a/controllers/cloudstackmachine_controller_test.go
+++ b/controllers/cloudstackmachine_controller_test.go
@@ -32,6 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"strings"
 )
 
 var _ = Describe("CloudStackMachineReconciler", func() {
@@ -50,7 +51,7 @@ var _ = Describe("CloudStackMachineReconciler", func() {
 
 			// Setup a failure domain for the machine reconciler to find.
 			Ω(k8sClient.Create(ctx, dummies.CSFailureDomain1)).Should(Succeed())
-			setClusterReady()
+			setClusterReady(k8sClient)
 		})
 
 		It("Should call GetOrCreateVMInstance and set Status.Ready to true", func() {
@@ -197,8 +198,9 @@ var _ = Describe("CloudStackMachineReconciler", func() {
 
 	Context("With a fake ctrlRuntimeClient and no test Env at all.", func() {
 		BeforeEach(func() {
-			dummies.SetDummyVars()
 			setupFakeTestClient()
+			dummies.CSCluster.Spec.FailureDomains = dummies.CSCluster.Spec.FailureDomains[:1]
+			dummies.CSCluster.Spec.FailureDomains[0].Name = dummies.CSFailureDomain1.Spec.Name
 		})
 
 		It("Should exit having not found a failure domain to place the machine in.", func() {
@@ -218,6 +220,47 @@ var _ = Describe("CloudStackMachineReconciler", func() {
 			res, err := MachineReconciler.Reconcile(ctx, ctrl.Request{NamespacedName: requestNamespacedName})
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(res.RequeueAfter).ShouldNot(BeZero())
+		})
+
+		It("Should create event Machine instance is Running", func() {
+			key := client.ObjectKeyFromObject(dummies.CSCluster)
+			dummies.CAPIMachine.Name = "someMachine"
+			dummies.CAPIMachine.Spec.Bootstrap.DataSecretName = &dummies.BootstrapSecret.Name
+			dummies.CSMachine1.OwnerReferences = append(dummies.CSMachine1.OwnerReferences, metav1.OwnerReference{
+				Kind:       "Machine",
+				APIVersion: clusterv1.GroupVersion.String(),
+				Name:       dummies.CAPIMachine.Name,
+				UID:        "uniqueness",
+			})
+			mockCloudClient.EXPECT().GetOrCreateVMInstance(
+				gomock.Any(), gomock.Any(), gomock.Any(),
+				gomock.Any(), gomock.Any(), gomock.Any()).Do(
+				func(arg1, _, _, _, _, _ interface{}) {
+					arg1.(*infrav1.CloudStackMachine).Status.InstanceState = "Running"
+				}).AnyTimes()
+			Ω(fakeCtrlClient.Get(ctx, key, dummies.CSCluster)).Should(Succeed())
+			Ω(fakeCtrlClient.Create(ctx, dummies.CAPIMachine)).Should(Succeed())
+			Ω(fakeCtrlClient.Create(ctx, dummies.CSMachine1)).Should(Succeed())
+			Ω(fakeCtrlClient.Create(ctx, dummies.CSFailureDomain1)).Should(Succeed())
+			Ω(fakeCtrlClient.Create(ctx, dummies.ACSEndpointSecret1)).Should(Succeed())
+			Ω(fakeCtrlClient.Create(ctx, dummies.BootstrapSecret)).Should(Succeed())
+
+			setClusterReady(fakeCtrlClient)
+
+			requestNamespacedName := types.NamespacedName{Namespace: dummies.ClusterNameSpace, Name: dummies.CSMachine1.Name}
+			MachineReconciler.AsFailureDomainUser(&dummies.CSFailureDomain1.Spec)
+			res, err := MachineReconciler.Reconcile(ctx, ctrl.Request{NamespacedName: requestNamespacedName})
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(res.RequeueAfter).Should(BeZero())
+			
+			Eventually(func() bool {
+				for event := range fakeRecorder.Events {
+					return strings.Contains(event, "Normal Created CloudStack instance Created") ||
+						strings.Contains(event, "Normal Running Machine instance is Running...") ||
+						strings.Contains(event, "Normal Machine State Checker CloudStackMachineStateChecker Instance1 created")
+				}
+				return false
+			}, timeout).Should(BeTrue())
 		})
 	})
 })

--- a/controllers/utils/base_reconciler.go
+++ b/controllers/utils/base_reconciler.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"k8s.io/client-go/tools/record"
 	"strings"
 	"time"
 
@@ -46,6 +47,7 @@ type ReconcilerBase struct {
 	Scheme     *runtime.Scheme
 	K8sClient  client.Client
 	CSClient   cloud.Client
+	Recorder   record.EventRecorder
 	CloudClientExtension
 }
 
@@ -453,6 +455,7 @@ func (r *ReconcilerBase) InitFromMgr(mgr ctrl.Manager, client cloud.Client) {
 	r.K8sClient = mgr.GetClient()
 	r.BaseLogger = ctrl.Log.WithName("controllers")
 	r.Scheme = mgr.GetScheme()
+	r.Recorder = mgr.GetEventRecorderFor("capc-controller-manager")
 	r.CSClient = client
 }
 

--- a/main.go
+++ b/main.go
@@ -148,6 +148,7 @@ func main() {
 	base := utils.ReconcilerBase{
 		K8sClient:  mgr.GetClient(),
 		BaseLogger: ctrl.Log.WithName("controllers"),
+		Recorder:   mgr.GetEventRecorderFor("capc-controller-manager"),
 		Scheme:     mgr.GetScheme()}
 
 	setupReconcilers(base, mgr)


### PR DESCRIPTION
*Issue #, if available:*
For better diagnosis cloudstack machine controller issue, several events are added to CloudStackMachine during reconcile.
*Description of changes:*
Events are created during reconciling CloudStackMachine
*Testing performed:*
Unit testing, manual testing. 

```
Events:
  Type    Reason    Age                    From                     Message
  ----    ------    ----                   ----                     -------
  Normal  Creating  5m30s (x19 over 7m)    capc-machine-controller  Bootstrap DataSecretName not yet available.
  Normal  Created   5m21s                  capc-machine-controller  CloudStack instance Created
  Normal  Running   5m20s (x2 over 5m21s)  capc-machine-controller  Machine instance is Running...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->