### PR TITLE
Add exceeding account quota e2e test case

### DIFF
--- a/test/e2e/config/cloudstack.yaml
+++ b/test/e2e/config/cloudstack.yaml
@@ -95,6 +95,7 @@ providers:
       - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-custom-disk-offering.yaml"
       - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-subdomain.yaml"
       - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-invalid-ip.yaml"
+      - sourcePath: "../data/infrastructure-cloudstack/v1beta2/cluster-template-account-quota.yaml"
       - sourcePath: "../data/shared/v1beta1/metadata.yaml"
     versions:
       - name: v1.0.0
@@ -149,6 +150,7 @@ variables:
 
   CLOUDSTACK_SUBDOMAIN_PATH: SUBDOMAIN
   CLOUDSTACK_SUBDOMAIN_ACCOUNT_NAME:	SUBDOMAIN-ADMIN
+  CLOUDSTACK_QUOTA_ACCOUNT_NAME: quota-account
 
   CONFORMANCE_CONFIGURATION: "./data/kubetest/conformance.yaml"
   CONFORMANCE_WORKER_MACHINE_COUNT: "3"

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-account-quota/cloudstack-cluster.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-account-quota/cloudstack-cluster.yaml
@@ -1,0 +1,19 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: CloudStackCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  failureDomains:
+  - name: ${CLOUDSTACK_FD1_NAME}
+    acsEndpoint:
+      name: ${CLOUDSTACK_FD1_SECRET_NAME}
+      namespace: default
+    zone:
+      name :  ${CLOUDSTACK_ZONE_NAME}
+      network: 
+        name: ${CLOUDSTACK_NETWORK_NAME}
+    account: ${CLOUDSTACK_QUOTA_ACCOUNT_NAME}
+    domain: ${CLOUDSTACK_DOMAIN_NAME}
+  controlPlaneEndpoint:
+    host: ""
+    port: 6443

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-account-quota/kustomization.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-account-quota/kustomization.yaml
@@ -1,0 +1,7 @@
+bases:
+  - ../bases/cluster-with-kcp.yaml
+  - ../bases/md.yaml
+
+patchesStrategicMerge:
+- ./cloudstack-cluster.yaml
+- ./md.yaml

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-account-quota/md.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-account-quota/md.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: CloudStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      offering: 
+        name: ${CLOUDSTACK_CONTROL_PLANE_MACHINE_OFFERING}
+      template: 
+        name: ${CLOUDSTACK_TEMPLATE_NAME}
+      sshKey: ${CLOUDSTACK_SSH_KEY_NAME}
+      affinity: pro
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: CloudStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      offering: 
+        name: ${CLOUDSTACK_WORKER_MACHINE_OFFERING}
+      template: 
+        name: ${CLOUDSTACK_TEMPLATE_NAME}
+      sshKey: ${CLOUDSTACK_SSH_KEY_NAME}
+      affinity: pro

--- a/test/e2e/invalid_resource.go
+++ b/test/e2e/invalid_resource.go
@@ -104,6 +104,10 @@ func InvalidResourceSpec(ctx context.Context, inputGetter func() CommonSpecInput
 		testInvalidResource(ctx, input, "invalid-ip", "no public addresses found in available networks")
 	})
 
+	It("Should fail due to exceeding account quota [TC22]", func() {
+		testInvalidResource(ctx, input, "account-quota", "CloudStack API error 535 (CSExceptionErrorCode: 9999): Maximum amount of resources of Type")
+	})
+
 	Context("When starting with a healthy cluster", func() {
 		var logFolder string
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding an e2e test case that test exceeding account's quota (e.g. instance limits)

*Testing performed:*

e2e testing


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->