### PR TITLE
Add finalizer only when deployVM no error

### DIFF
--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -223,11 +223,11 @@ func (r *CloudStackMachineReconciliationRunner) GetOrCreateVMInstance() (retRes 
 		r.Recorder.Eventf(r.ReconciliationSubject, "Warning", "Creating", CSMachineCreationFailed, err.Error())
 	}
 	if err == nil && !controllerutil.ContainsFinalizer(r.ReconciliationSubject, infrav1.MachineFinalizer) { // Fetched or Created?
+		controllerutil.AddFinalizer(r.ReconciliationSubject, infrav1.MachineFinalizer)
 		r.Recorder.Eventf(r.ReconciliationSubject, "Normal", "Created", CSMachineCreationSuccess)
 		r.Log.Info(CSMachineCreationSuccess, "instanceStatus", r.ReconciliationSubject.Status)
 	}
-	// Always add the finalizer regardless. It can't be added twice anyway.
-	controllerutil.AddFinalizer(r.ReconciliationSubject, infrav1.MachineFinalizer)
+	
 	return ctrl.Result{}, err
 }
 

--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -223,9 +223,9 @@ func (r *CloudStackMachineReconciliationRunner) GetOrCreateVMInstance() (retRes 
 		r.Recorder.Eventf(r.ReconciliationSubject, "Warning", "Creating", CSMachineCreationFailed, err.Error())
 	}
 	if err == nil && !controllerutil.ContainsFinalizer(r.ReconciliationSubject, infrav1.MachineFinalizer) { // Fetched or Created?
-		// adding a finalizer will require CPAC reconcile-delete trying to destroy associated VM through instanceID,
-		// so if err is not nil, which means it could not get associated VM through instanceID or name, we should not add finalizer to CloudStackMachine,
-		// otherwise, reconciler-delete will be stuck trying to wait instanceID to ba available.
+		// Adding a finalizer will make reconcile-delete try to destroy the associated VM through instanceID.
+		// If err is not nil, it means CAPC could not get an associated VM through instanceID or name, so we should not add a finalizer to this CloudStackMachine,
+		// Otherwise, reconcile-delete will be stuck trying to wait for instanceID to be available.
 		controllerutil.AddFinalizer(r.ReconciliationSubject, infrav1.MachineFinalizer)
 		r.Recorder.Eventf(r.ReconciliationSubject, "Normal", "Created", CSMachineCreationSuccess)
 		r.Log.Info(CSMachineCreationSuccess, "instanceStatus", r.ReconciliationSubject.Status)

--- a/controllers/cloudstackmachine_controller_test.go
+++ b/controllers/cloudstackmachine_controller_test.go
@@ -72,7 +72,7 @@ var _ = Describe("CloudStackMachineReconciler", func() {
 				key := client.ObjectKey{Namespace: dummies.ClusterNameSpace, Name: dummies.CSMachine1.Name}
 				if err := k8sClient.Get(ctx, key, tempMachine); err == nil {
 					if tempMachine.Status.Ready == true {
-						return true
+						return len(tempMachine.ObjectMeta.Finalizers) > 0
 					}
 				}
 				return false

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -275,13 +275,13 @@ func (c *client) GetOrCreateVMInstance(
 		listVirtualMachineParams.SetZoneid(fd.Spec.Zone.ID)
 		listVirtualMachineParams.SetNetworkid(fd.Spec.Zone.Network.ID)
 		listVirtualMachineParams.SetName(csMachine.Name)
-		if listVirtualMachinesResponse, err2 := c.cs.VirtualMachine.ListVirtualMachines(listVirtualMachineParams); err2 == nil && listVirtualMachinesResponse.Count > 0 {
-			csMachine.Spec.InstanceID = pointer.StringPtr(listVirtualMachinesResponse.VirtualMachines[0].Id)
-			csMachine.Status.InstanceState = listVirtualMachinesResponse.VirtualMachines[0].State
-		} else {
+		listVirtualMachinesResponse, err2 := c.cs.VirtualMachine.ListVirtualMachines(listVirtualMachineParams)
+		if err2 != nil || listVirtualMachinesResponse.Count <= 0 {
 			c.customMetrics.EvaluateErrorAndIncrementAcsReconciliationErrorCounter(err2)
 			return err
 		}
+		csMachine.Spec.InstanceID = pointer.StringPtr(listVirtualMachinesResponse.VirtualMachines[0].Id)
+		csMachine.Status.InstanceState = listVirtualMachinesResponse.VirtualMachines[0].State
 	} else {
 		csMachine.Spec.InstanceID = pointer.StringPtr(deployVMResp.Id)
 		csMachine.Status.Status = pointer.String(metav1.StatusSuccess)

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -277,13 +277,15 @@ func (c *client) GetOrCreateVMInstance(
 		listVirtualMachineParams.SetName(csMachine.Name)
 		if listVirtualMachinesResponse, err2 := c.cs.VirtualMachine.ListVirtualMachines(listVirtualMachineParams); err2 == nil && listVirtualMachinesResponse.Count > 0 {
 			csMachine.Spec.InstanceID = pointer.StringPtr(listVirtualMachinesResponse.VirtualMachines[0].Id)
+			csMachine.Status.InstanceState = listVirtualMachinesResponse.VirtualMachines[0].State
 		} else {
 			c.customMetrics.EvaluateErrorAndIncrementAcsReconciliationErrorCounter(err2)
+			return err
 		}
-		return err
+	} else {
+		csMachine.Spec.InstanceID = pointer.StringPtr(deployVMResp.Id)
+		csMachine.Status.Status = pointer.String(metav1.StatusSuccess)
 	}
-	csMachine.Spec.InstanceID = pointer.StringPtr(deployVMResp.Id)
-	csMachine.Status.Status = pointer.String(metav1.StatusSuccess)
 	// Resolve uses a VM metrics request response to fill cloudstack machine status.
 	// The deployment response is insufficient.
 	return c.ResolveVMInstanceDetails(csMachine)


### PR DESCRIPTION
*Issue #, if available:*
When deployVM failed, for example, due to invalid serviceOffering. The instanceID is not set and CAPC object could not be deleted due to missing InstanceID.
*Description of changes:*
Do not add finalizer to CAPC object when error happened during deployVM.
*Testing performed:*
Manual testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->