### PR TITLE
tests: Fix error for when a VM is unable to deploy

### DIFF
--- a/test/e2e/invalid_resource.go
+++ b/test/e2e/invalid_resource.go
@@ -40,11 +40,12 @@ import (
 )
 
 var (
-	specName         = "invalid-resource"
-	input            CommonSpecInput
-	namespace        *corev1.Namespace
-	cancelWatches    context.CancelFunc
-	clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+	specName           = "invalid-resource"
+	input              CommonSpecInput
+	namespace          *corev1.Namespace
+	cancelWatches      context.CancelFunc
+	clusterResources   *clusterctl.ApplyClusterTemplateAndWaitResult
+	instanceStateError = "\"instanceState\":\"Error\""
 )
 
 // InvalidResourceSpec implements a test that verifies that creating a new cluster fails when the specified resource does not exist
@@ -89,7 +90,7 @@ func InvalidResourceSpec(ctx context.Context, inputGetter func() CommonSpecInput
 	})
 
 	It("Should fail due to the compute resources are not sufficient for the specified offering [TC8]", func() {
-		testInvalidResource(ctx, input, "insufficient-compute-resources", "Unable to create a deployment for VM")
+		testInvalidResource(ctx, input, "insufficient-compute-resources", instanceStateError)
 	})
 
 	It("Should fail due to the specified disk offer is not customized but the disk size is specified", func() {
@@ -134,8 +135,7 @@ func InvalidResourceSpec(ctx context.Context, inputGetter func() CommonSpecInput
 
 		It("Should fail to upgrade worker machine due to insufficient compute resources", func() {
 			By("Making sure the expected error didn't occur yet")
-			expectedError := "Unable to create a deployment for VM"
-			Expect(errorExistsInLog(logFolder, expectedError)).To(BeFalse())
+			Expect(errorExistsInLog(logFolder, instanceStateError)).To(BeFalse())
 
 			By("Increasing the machine deployment instance size")
 			deployment := clusterResources.MachineDeployments[0]
@@ -144,13 +144,12 @@ func InvalidResourceSpec(ctx context.Context, inputGetter func() CommonSpecInput
 			upgradeMachineDeploymentInfrastructureRef(ctx, deployment)
 
 			By("Checking for the expected error")
-			waitForErrorInLog(logFolder, expectedError)
+			waitForErrorInLog(logFolder, instanceStateError)
 		})
 
 		It("Should fail to upgrade control plane machine due to insufficient compute resources", func() {
 			By("Making sure the expected error didn't occur yet")
-			expectedError := "Unable to create a deployment for VM"
-			Expect(errorExistsInLog(logFolder, expectedError)).To(BeFalse())
+			Expect(errorExistsInLog(logFolder, instanceStateError)).To(BeFalse())
 
 			By("Increasing the machine deployment instance size")
 			cp := clusterResources.ControlPlane
@@ -159,7 +158,7 @@ func InvalidResourceSpec(ctx context.Context, inputGetter func() CommonSpecInput
 			upgradeControlPlaneInfrastructureRef(ctx, cp)
 
 			By("Checking for the expected error")
-			waitForErrorInLog(logFolder, expectedError)
+			waitForErrorInLog(logFolder, instanceStateError)
 		})
 	})
 


### PR DESCRIPTION
Fixes the failing invalid_resource_test to a more consistent error message