### PR TITLE
Add zoneID parameter when retrieving service/disk offering

### DIFF
--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ func (c *client) ResolveVMInstanceDetails(csMachine *infrav1.CloudStackMachine) 
 	return errors.New("no match found")
 }
 
-func (c *client) ResolveServiceOffering(csMachine *infrav1.CloudStackMachine) (offeringID string, retErr error) {
+func (c *client) ResolveServiceOffering(csMachine *infrav1.CloudStackMachine, zoneID string) (offeringID string, retErr error) {
 	if len(csMachine.Spec.Offering.ID) > 0 {
 		csOffering, count, err := c.cs.ServiceOffering.GetServiceOfferingByID(csMachine.Spec.Offering.ID)
 		if err != nil {
@@ -102,14 +102,14 @@ func (c *client) ResolveServiceOffering(csMachine *infrav1.CloudStackMachine) (o
 		}
 		return csMachine.Spec.Offering.ID, nil
 	}
-	offeringID, count, err := c.cs.ServiceOffering.GetServiceOfferingID(csMachine.Spec.Offering.Name)
+	offeringID, count, err := c.cs.ServiceOffering.GetServiceOfferingID(csMachine.Spec.Offering.Name, cloudstack.WithZone(zoneID))
 	if err != nil {
 		c.customMetrics.EvaluateErrorAndIncrementAcsReconciliationErrorCounter(err)
 		return "", multierror.Append(retErr, errors.Wrapf(
-			err, "could not get Service Offering ID from %s", csMachine.Spec.Offering.Name))
+			err, "could not get Service Offering ID from %s in zone %s", csMachine.Spec.Offering.Name, zoneID))
 	} else if count != 1 {
 		return "", multierror.Append(retErr, errors.Errorf(
-			"expected 1 Service Offering with name %s, but got %d", csMachine.Spec.Offering.Name, count))
+			"expected 1 Service Offering with name %s in zone %s, but got %d", csMachine.Spec.Offering.Name, zoneID, count))
 	}
 	return offeringID, nil
 }
@@ -221,7 +221,7 @@ func (c *client) GetOrCreateVMInstance(
 		return err
 	}
 
-	offeringID, err := c.ResolveServiceOffering(csMachine)
+	offeringID, err := c.ResolveServiceOffering(csMachine, fd.Spec.Zone.ID)
 	if err != nil {
 		return err
 	}

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -161,15 +161,15 @@ func (c *client) ResolveDiskOffering(csMachine *infrav1.CloudStackMachine, zoneI
 				err, "could not get DiskOffering ID from %s", csMachine.Spec.DiskOffering.Name))
 		} else if count != 1 {
 			return "", multierror.Append(retErr, errors.Errorf(
-				"expected 1 DiskOffering with name %s, but got %d", csMachine.Spec.DiskOffering.Name, count))
+				"expected 1 DiskOffering with name %s in zone %s, but got %d", csMachine.Spec.DiskOffering.Name, zoneID, count))
 		} else if len(csMachine.Spec.DiskOffering.ID) > 0 && diskID != csMachine.Spec.DiskOffering.ID {
 			return "", multierror.Append(retErr, errors.Errorf(
-				"diskOffering ID %s does not match ID %s returned using name %s",
-				csMachine.Spec.DiskOffering.ID, diskID, csMachine.Spec.DiskOffering.Name))
+				"diskOffering ID %s does not match ID %s returned using name %s in zone %s",
+				csMachine.Spec.DiskOffering.ID, diskID, csMachine.Spec.DiskOffering.Name, zoneID))
 		} else if len(diskID) == 0 {
 			return "", multierror.Append(retErr, errors.Errorf(
-				"empty diskOffering ID %s returned using name %s",
-				diskID, csMachine.Spec.DiskOffering.Name))
+				"empty diskOffering ID %s returned using name %s in zone %s",
+				diskID, csMachine.Spec.DiskOffering.Name, zoneID))
 		}
 		diskOfferingID = diskID
 	}

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -151,10 +151,10 @@ func (c *client) ResolveTemplate(
 // ResolveDiskOffering Retrieves diskOffering by using disk offering ID if ID is provided and confirm returned
 // disk offering name matches name provided in spec.
 // If disk offering ID is not provided, the disk offering name is used to retrieve disk offering ID.
-func (c *client) ResolveDiskOffering(csMachine *infrav1.CloudStackMachine) (diskOfferingID string, retErr error) {
+func (c *client) ResolveDiskOffering(csMachine *infrav1.CloudStackMachine, zoneID string) (diskOfferingID string, retErr error) {
 	diskOfferingID = csMachine.Spec.DiskOffering.ID
 	if len(csMachine.Spec.DiskOffering.Name) > 0 {
-		diskID, count, err := c.cs.DiskOffering.GetDiskOfferingID(csMachine.Spec.DiskOffering.Name)
+		diskID, count, err := c.cs.DiskOffering.GetDiskOfferingID(csMachine.Spec.DiskOffering.Name, cloudstack.WithZone(zoneID))
 		if err != nil {
 			c.customMetrics.EvaluateErrorAndIncrementAcsReconciliationErrorCounter(err)
 			return "", multierror.Append(retErr, errors.Wrapf(
@@ -229,7 +229,7 @@ func (c *client) GetOrCreateVMInstance(
 	if err != nil {
 		return err
 	}
-	diskOfferingID, err := c.ResolveDiskOffering(csMachine)
+	diskOfferingID, err := c.ResolveDiskOffering(csMachine, fd.Spec.Zone.ID)
 	if err != nil {
 		return err
 	}

--- a/pkg/cloud/instance_test.go
+++ b/pkg/cloud/instance_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -143,7 +143,7 @@ var _ = Describe("Instance", func() {
 
 		It("returns errors occurring while fetching service offering information", func() {
 			expectVMNotFound()
-			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).Return("", -1, unknownError)
+			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).Return("", -1, unknownError)
 			Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
 				ShouldNot(Succeed())
@@ -151,7 +151,7 @@ var _ = Describe("Instance", func() {
 
 		It("returns errors if more than one service offering found", func() {
 			expectVMNotFound()
-			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).Return("", 2, nil)
+			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).Return("", 2, nil)
 			Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
 				ShouldNot(Succeed())
@@ -159,7 +159,7 @@ var _ = Describe("Instance", func() {
 
 		It("returns errors while fetching template", func() {
 			expectVMNotFound()
-			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).
+			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
 				Return(dummies.CSMachine1.Spec.Offering.ID, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).
 				Return("", -1, unknownError)
@@ -170,7 +170,7 @@ var _ = Describe("Instance", func() {
 
 		It("returns errors when more than one template found", func() {
 			expectVMNotFound()
-			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).
+			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
 				Return(dummies.CSMachine1.Spec.Offering.ID, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).Return("", 2, nil)
 			Ω(client.GetOrCreateVMInstance(
@@ -180,7 +180,7 @@ var _ = Describe("Instance", func() {
 
 		It("returns errors when more than one diskoffering found", func() {
 			expectVMNotFound()
-			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).
+			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
 				Return(dummies.CSMachine1.Spec.Offering.ID, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).Return(dummies.CSMachine1.Spec.Template.ID, 1, nil)
 			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 2, nil)
@@ -191,7 +191,7 @@ var _ = Describe("Instance", func() {
 
 		It("returns errors when fetching diskoffering", func() {
 			expectVMNotFound()
-			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).
+			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
 				Return(dummies.CSMachine1.Spec.Offering.ID, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).Return(dummies.CSMachine1.Spec.Template.ID, 1, nil)
 			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 1, nil)
@@ -204,7 +204,7 @@ var _ = Describe("Instance", func() {
 		It("returns errors when disk size not zero for non-customized disk offering", func() {
 			expectVMNotFound()
 			dummies.CSMachine1.Spec.DiskOffering.CustomSize = 1
-			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).
+			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
 				Return(dummies.CSMachine1.Spec.Offering.ID, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).Return(dummies.CSMachine1.Spec.Template.ID, 1, nil)
 			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 1, nil)
@@ -217,7 +217,7 @@ var _ = Describe("Instance", func() {
 		It("returns errors when disk size zero for customized disk offering", func() {
 			expectVMNotFound()
 			dummies.CSMachine1.Spec.DiskOffering.CustomSize = 0
-			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).
+			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
 				Return(dummies.CSMachine1.Spec.Offering.ID, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).Return(dummies.CSMachine1.Spec.Template.ID, 1, nil)
 			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 1, nil)
@@ -229,7 +229,7 @@ var _ = Describe("Instance", func() {
 
 		It("handles deployment errors", func() {
 			expectVMNotFound()
-			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).
+			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
 				Return(offeringFakeID, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).
 				Return(templateFakeID, 1, nil)
@@ -282,7 +282,7 @@ var _ = Describe("Instance", func() {
 				dummies.CSMachine1.Spec.Offering.Name = "offering"
 				dummies.CSMachine1.Spec.Template.Name = "template"
 
-				sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).Return(offeringFakeID, 1, nil)
+				sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).Return(offeringFakeID, 1, nil)
 				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 1, nil)
 				dos.EXPECT().GetDiskOfferingByID(dummies.CSMachine1.Spec.DiskOffering.ID).Return(&cloudstack.DiskOffering{Iscustomized: false}, 1, nil)
 				ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).
@@ -298,7 +298,7 @@ var _ = Describe("Instance", func() {
 				dummies.CSMachine1.Spec.Template.Name = "template"
 				dummies.CSMachine1.Spec.DiskOffering = infrav1.CloudStackResourceDiskOffering{}
 
-				sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).Return(offeringFakeID, 1, nil)
+				sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).Return(offeringFakeID, 1, nil)
 				ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).
 					Return(templateFakeID, 1, nil)
 
@@ -328,7 +328,7 @@ var _ = Describe("Instance", func() {
 				dummies.CSMachine1.Spec.Offering.Name = "offering"
 				dummies.CSMachine1.Spec.Template.Name = ""
 
-				sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name).Return(offeringFakeID, 1, nil)
+				sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).Return(offeringFakeID, 1, nil)
 				ts.EXPECT().GetTemplateByID(dummies.CSMachine1.Spec.Template.ID, executableFilter).Return(&cloudstack.Template{Name: ""}, 1, nil)
 				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 1, nil)
 				dos.EXPECT().GetDiskOfferingByID(dummies.CSMachine1.Spec.DiskOffering.ID).Return(&cloudstack.DiskOffering{Iscustomized: false}, 1, nil)

--- a/pkg/cloud/instance_test.go
+++ b/pkg/cloud/instance_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Instance", func() {
 			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
 				Return(dummies.CSMachine1.Spec.Offering.ID, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).Return(dummies.CSMachine1.Spec.Template.ID, 1, nil)
-			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 2, nil)
+			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID, 2, nil)
 			Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
 				ShouldNot(Succeed())
@@ -194,7 +194,7 @@ var _ = Describe("Instance", func() {
 			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
 				Return(dummies.CSMachine1.Spec.Offering.ID, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).Return(dummies.CSMachine1.Spec.Template.ID, 1, nil)
-			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 1, nil)
+			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID, 1, nil)
 			dos.EXPECT().GetDiskOfferingByID(diskOfferingFakeID).Return(&cloudstack.DiskOffering{Iscustomized: false}, 1, unknownError)
 			Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
@@ -207,7 +207,7 @@ var _ = Describe("Instance", func() {
 			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
 				Return(dummies.CSMachine1.Spec.Offering.ID, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).Return(dummies.CSMachine1.Spec.Template.ID, 1, nil)
-			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 1, nil)
+			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID, 1, nil)
 			dos.EXPECT().GetDiskOfferingByID(diskOfferingFakeID).Return(&cloudstack.DiskOffering{Iscustomized: false}, 1, nil)
 			Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
@@ -220,7 +220,7 @@ var _ = Describe("Instance", func() {
 			sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
 				Return(dummies.CSMachine1.Spec.Offering.ID, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).Return(dummies.CSMachine1.Spec.Template.ID, 1, nil)
-			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 1, nil)
+			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID, 1, nil)
 			dos.EXPECT().GetDiskOfferingByID(diskOfferingFakeID).Return(&cloudstack.DiskOffering{Iscustomized: true}, 1, nil)
 			Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
@@ -233,7 +233,7 @@ var _ = Describe("Instance", func() {
 				Return(offeringFakeID, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).
 				Return(templateFakeID, 1, nil)
-			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).
+			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).
 				Return(diskOfferingFakeID, 1, nil)
 			dos.EXPECT().GetDiskOfferingByID(diskOfferingFakeID).
 				Return(&cloudstack.DiskOffering{Iscustomized: false}, 1, nil)
@@ -283,7 +283,7 @@ var _ = Describe("Instance", func() {
 				dummies.CSMachine1.Spec.Template.Name = "template"
 
 				sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).Return(offeringFakeID, 1, nil)
-				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 1, nil)
+				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID, 1, nil)
 				dos.EXPECT().GetDiskOfferingByID(dummies.CSMachine1.Spec.DiskOffering.ID).Return(&cloudstack.DiskOffering{Iscustomized: false}, 1, nil)
 				ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).
 					Return(templateFakeID, 1, nil)
@@ -315,7 +315,7 @@ var _ = Describe("Instance", func() {
 				sos.EXPECT().GetServiceOfferingByID(dummies.CSMachine1.Spec.Offering.ID).Return(&cloudstack.ServiceOffering{Name: ""}, 1, nil)
 				ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID).
 					Return(templateFakeID, 1, nil)
-				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 1, nil)
+				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID, 1, nil)
 				dos.EXPECT().GetDiskOfferingByID(dummies.CSMachine1.Spec.DiskOffering.ID).Return(&cloudstack.DiskOffering{Iscustomized: false}, 1, nil)
 
 				ActionAndAssert()
@@ -330,7 +330,7 @@ var _ = Describe("Instance", func() {
 
 				sos.EXPECT().GetServiceOfferingID(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).Return(offeringFakeID, 1, nil)
 				ts.EXPECT().GetTemplateByID(dummies.CSMachine1.Spec.Template.ID, executableFilter).Return(&cloudstack.Template{Name: ""}, 1, nil)
-				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 1, nil)
+				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID, 1, nil)
 				dos.EXPECT().GetDiskOfferingByID(dummies.CSMachine1.Spec.DiskOffering.ID).Return(&cloudstack.DiskOffering{Iscustomized: false}, 1, nil)
 
 				ActionAndAssert()
@@ -345,7 +345,7 @@ var _ = Describe("Instance", func() {
 
 				sos.EXPECT().GetServiceOfferingByID(dummies.CSMachine1.Spec.Offering.ID).
 					Return(&cloudstack.ServiceOffering{Name: "offering"}, 1, nil)
-				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).
+				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).
 					Return(diskOfferingFakeID, 1, nil)
 				dos.EXPECT().GetDiskOfferingByID(dummies.CSMachine1.Spec.DiskOffering.ID).
 					Return(&cloudstack.DiskOffering{Iscustomized: false}, 1, nil)
@@ -364,7 +364,7 @@ var _ = Describe("Instance", func() {
 
 				sos.EXPECT().GetServiceOfferingByID(dummies.CSMachine1.Spec.Offering.ID).Return(&cloudstack.ServiceOffering{Name: "offering"}, 1, nil)
 				ts.EXPECT().GetTemplateByID(dummies.CSMachine1.Spec.Template.ID, executableFilter).Return(&cloudstack.Template{Name: "template"}, 1, nil)
-				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID, 1, nil)
+				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID, 1, nil)
 				dos.EXPECT().GetDiskOfferingByID(dummies.CSMachine1.Spec.DiskOffering.ID).Return(&cloudstack.DiskOffering{Iscustomized: false}, 1, nil)
 
 				ActionAndAssert()
@@ -416,7 +416,7 @@ var _ = Describe("Instance", func() {
 
 				sos.EXPECT().GetServiceOfferingByID(dummies.CSMachine1.Spec.Offering.ID).Return(&cloudstack.ServiceOffering{Name: "offering"}, 1, nil)
 				ts.EXPECT().GetTemplateByID(dummies.CSMachine1.Spec.Template.ID, executableFilter).Return(&cloudstack.Template{Name: "template"}, 1, nil)
-				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name).Return(diskOfferingFakeID+"-not-match", 1, nil)
+				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID+"-not-match", 1, nil)
 				requiredRegexp := "diskOffering ID %s does not match ID %s returned using name %s"
 				Ω(client.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).


### PR DESCRIPTION
*Issue #, if available:*
[CAPC does not resolve service offering with zone as additional filtering parameter](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/issues/207)
Also noticed similar issue happened to diskoffering too.
*Description of changes:*
Add zoneID when calling CloudStack API to retrieve service offering by name or retrieve disk offering by name
*Testing performed:*
Unit Test, manual testing.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->