### PR TITLE
change goheader copyright year rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,8 +3,10 @@ linters-settings:
     values:
       const:
         AUTHOR: The Kubernetes Authors
+      regexp:
+        YR: '\d\d\d\d'
     template:  |-
-      Copyright {{ YEAR }} {{ AUTHOR }}.
+      Copyright {{ YR }} {{ AUTHOR }}.
 
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.


### PR DESCRIPTION
*Issue #, if available:*
Goheader return false error complaining copyright year is not currently year

*Description of changes:*
Change goheader template to allow four digits as year instead of checking current year

*Testing performed:*
Manual testing


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->