### PR TITLE
GetPublicIPs: never choose an already assigned IP

### DIFF
--- a/pkg/cloud/isolated_network.go
+++ b/pkg/cloud/isolated_network.go
@@ -141,12 +141,6 @@ func (c *client) GetPublicIP(
 		// Ignore already allocated here since the IP was specified.
 		return publicAddresses.PublicIpAddresses[0], nil
 	} else if publicAddresses.Count > 0 { // Endpoint not specified.
-		// TODO: Use tags to prevent clash with this logic.
-		for _, v := range publicAddresses.PublicIpAddresses { // Pick first available address.
-			if v.Allocated != "" && v.Associatednetworkid == isoNet.Spec.ID && !v.Issourcenat { // IP Already allocated.
-				return v, nil
-			}
-		}
 		for _, v := range publicAddresses.PublicIpAddresses { // Pick first available address.
 			if v.Allocated == "" { // Found un-allocated Public IP.
 				return v, nil


### PR DESCRIPTION
*Description of changes:*

This fix removes a condition where an already assigned public IP inside the same Isolated network would be chosen as the IP of another cluster. This condition could only be triggered whenever a new controlPlaneEndpoint is chosen for a new cluster.

*Testing performed:*

Deployed on our staging cluster. Provisioned several clusters inside the same guest network, checked all clusters were deployed properly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->