### PR TITLE
Replace k8s.gcr.io with registry.k8s.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ETCD := $(TOOLS_BIN_DIR)/etcd
 STAGING_REGISTRY := gcr.io/k8s-staging-capi-cloudstack
 STAGING_BUCKET ?= artifacts.k8s-staging-capi-cloudstack.appspot.com
 BUCKET ?= $(STAGING_BUCKET)
-PROD_REGISTRY ?= k8s.gcr.io/capi-cloudstack
+PROD_REGISTRY ?= registry.k8s.io/capi-cloudstack
 REGISTRY ?= $(STAGING_REGISTRY)
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
 PULL_BASE_REF ?= $(RELEASE_TAG)

--- a/docs/book/src/topics/unstacked-etcd.md
+++ b/docs/book/src/topics/unstacked-etcd.md
@@ -20,7 +20,7 @@ The value should point to an empty directory on the node
 ```yaml
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
+      imageRepository: registry.k8s.io
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
@@ -51,7 +51,7 @@ The value should point to an empty directory on the node
 ```yaml
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
+      imageRepository: registry.k8s.io
       etcd:
         external:
           endpoints:

--- a/test/e2e/data/infrastructure-cloudstack/v1beta1/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta1/bases/cluster-with-kcp.yaml
@@ -43,7 +43,7 @@ spec:
         kubeletExtraArgs:
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
+      imageRepository: registry.k8s.io
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta1/cluster-template-custom-disk-offering/cluster-with-custom-disk-offering.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta1/cluster-template-custom-disk-offering/cluster-with-custom-disk-offering.yaml
@@ -10,7 +10,7 @@ spec:
         kubeletExtraArgs:
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
+      imageRepository: registry.k8s.io
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta1/cluster-template-disk-offering/cluster-with-disk-offering.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta1/cluster-template-disk-offering/cluster-with-disk-offering.yaml
@@ -10,7 +10,7 @@ spec:
         kubeletExtraArgs:
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
+      imageRepository: registry.k8s.io
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta1/cluster-template-shared-network-kubevip/cluster-with-shared-network-and-kubevip.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta1/cluster-template-shared-network-kubevip/cluster-with-shared-network-and-kubevip.yaml
@@ -43,7 +43,7 @@ spec:
         kubeletExtraArgs:
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
+      imageRepository: registry.k8s.io
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/bases/cluster-with-kcp.yaml
@@ -48,7 +48,7 @@ spec:
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
+      imageRepository: registry.k8s.io
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-custom-disk-offering/cluster-with-custom-disk-offering.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-custom-disk-offering/cluster-with-custom-disk-offering.yaml
@@ -10,7 +10,7 @@ spec:
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
+      imageRepository: registry.k8s.io
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-disk-offering/cluster-with-disk-offering.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-disk-offering/cluster-with-disk-offering.yaml
@@ -10,7 +10,7 @@ spec:
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
+      imageRepository: registry.k8s.io
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-after/upgrade-cp.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-after/upgrade-cp.yaml
@@ -10,7 +10,7 @@ spec:
         kubeletExtraArgs:
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
+      imageRepository: registry.k8s.io
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-before/before.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-before/before.yaml
@@ -10,7 +10,7 @@ spec:
         kubeletExtraArgs:
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
+      imageRepository: registry.k8s.io
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-shared-network-kubevip/cluster-with-shared-network-and-kubevip.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-shared-network-kubevip/cluster-with-shared-network-and-kubevip.yaml
@@ -48,7 +48,7 @@ spec:
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
     clusterConfiguration:
-      imageRepository: k8s.gcr.io
+      imageRepository: registry.k8s.io
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'


### PR DESCRIPTION
*Issue #, if available:* https://github.com/kubernetes/k8s.io/issues/4738

*Description of changes:* This PR replaces all `k8s.gcr.io` references with `registry.k8s.io`. See the linked issue for more details.