### PR TITLE
Upgrade cluster-api dependency to v1.2.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ kind-cluster: cluster-api ## Create a kind cluster with a local Docker repositor
 	./cluster-api/hack/kind-install-for-capd.sh
 
 cluster-api: ## Clone cluster-api repository for tilt use.
-	git clone --branch v1.2.11 --depth 1 https://github.com/kubernetes-sigs/cluster-api.git
+	git clone --branch v1.2.12 --depth 1 https://github.com/kubernetes-sigs/cluster-api.git
 
 cluster-api/tilt-settings.json: hack/tilt-settings.json cluster-api
 	cp ./hack/tilt-settings.json cluster-api

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	k8s.io/client-go v0.25.3
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2
-	sigs.k8s.io/cluster-api v1.2.11
+	sigs.k8s.io/cluster-api v1.2.12
 	sigs.k8s.io/controller-runtime v0.13.1
 )
 
@@ -102,6 +102,6 @@ require (
 
 replace github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.0.0 // Indirect upgrade to address https://github.com/advisories/GHSA-w73w-5m7g-f7qc
 
-replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.2.11
+replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.2.12
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.11
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.12

--- a/go.sum
+++ b/go.sum
@@ -1047,8 +1047,8 @@ k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2/go.mod h1:OLgZIPagt7ERELqWJFomSt
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/cluster-api v1.2.11 h1:rtx6fp05qESvtALUGIizUAci0kmiEoVBG786C05L1jU=
-sigs.k8s.io/cluster-api v1.2.11/go.mod h1:VB4qC2t1WjqzBtJvxx3VImb/hLpdXjiWxkdd7OX29mA=
+sigs.k8s.io/cluster-api v1.2.12 h1:/1iFgWUR3Z+KZU9B4PJegmlQQo6uzQXBZNgOk63SLu4=
+sigs.k8s.io/cluster-api v1.2.12/go.mod h1:9+fLUuyRsKediKJYrbsyFj6Bmk59oopXpzj3g6/REM8=
 sigs.k8s.io/controller-runtime v0.13.1 h1:tUsRCSJVM1QQOOeViGeX3GMT3dQF1eePPw6sEE3xSlg=
 sigs.k8s.io/controller-runtime v0.13.1/go.mod h1:Zbz+el8Yg31jubvAEyglRZGdLAjplZl+PgtYNI6WNTI=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=

--- a/test/e2e/config/cloudstack.yaml
+++ b/test/e2e/config/cloudstack.yaml
@@ -15,11 +15,11 @@ images:
   ## PLEASE KEEP THESE UP TO DATE WITH THE COMPONENTS
 
   # Cluster API v1beta1 Preloads
-  - name: gcr.io/k8s-staging-cluster-api/cluster-api-controller:v1.2.11
+  - name: gcr.io/k8s-staging-cluster-api/cluster-api-controller:v1.2.12
     loadBehavior: tryLoad
-  - name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v1.2.11
+  - name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:v1.2.12
     loadBehavior: tryLoad
-  - name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v1.2.11
+  - name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:v1.2.12
     loadBehavior: tryLoad
   - name: gcr.io/k8s-staging-cluster-api/capd-manager-amd64:v1.0.0
     loadBehavior: tryLoad
@@ -34,8 +34,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.2.11
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/core-components.yaml"
+      - name: v1.2.12
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.12/core-components.yaml"
         type: "url"
         contract: v1beta1
         replacements:
@@ -47,8 +47,8 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.2.11
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/bootstrap-components.yaml"
+      - name: v1.2.12
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.12/bootstrap-components.yaml"
         type: "url"
         contract: v1beta1
         replacements:
@@ -60,8 +60,8 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.2.11
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/control-plane-components.yaml"
+      - name: v1.2.12
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.12/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         replacements:

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -12,8 +12,8 @@ require (
 	k8s.io/api v0.25.3
 	k8s.io/apimachinery v0.25.3
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
-	sigs.k8s.io/cluster-api v1.2.11
-	sigs.k8s.io/cluster-api/test v1.2.11
+	sigs.k8s.io/cluster-api v1.2.12
+	sigs.k8s.io/cluster-api/test v1.2.12
 	sigs.k8s.io/controller-runtime v0.13.1
 )
 
@@ -124,4 +124,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.11
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.12

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -986,10 +986,10 @@ k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/cluster-api v1.2.11 h1:rtx6fp05qESvtALUGIizUAci0kmiEoVBG786C05L1jU=
-sigs.k8s.io/cluster-api v1.2.11/go.mod h1:VB4qC2t1WjqzBtJvxx3VImb/hLpdXjiWxkdd7OX29mA=
-sigs.k8s.io/cluster-api/test v1.2.11 h1:lSkSs2q/eGCqNhnhdTdKQ+wz1l7emZB81bQJL367DOI=
-sigs.k8s.io/cluster-api/test v1.2.11/go.mod h1:iXCyt/916mWnKhU0xeCwgT7Xkn7jFbj/ArhIo07D8Kc=
+sigs.k8s.io/cluster-api v1.2.12 h1:/1iFgWUR3Z+KZU9B4PJegmlQQo6uzQXBZNgOk63SLu4=
+sigs.k8s.io/cluster-api v1.2.12/go.mod h1:9+fLUuyRsKediKJYrbsyFj6Bmk59oopXpzj3g6/REM8=
+sigs.k8s.io/cluster-api/test v1.2.12 h1:ylD8lUW6aZpmdkaAvRs6vBpN1zjiQuBr/kl6pya5FbY=
+sigs.k8s.io/cluster-api/test v1.2.12/go.mod h1:7rOSOBPkq5yqii/d/uf4EN/Ve4MWyYHGfQaCTTmlKsQ=
 sigs.k8s.io/controller-runtime v0.13.1 h1:tUsRCSJVM1QQOOeViGeX3GMT3dQF1eePPw6sEE3xSlg=
 sigs.k8s.io/controller-runtime v0.13.1/go.mod h1:Zbz+el8Yg31jubvAEyglRZGdLAjplZl+PgtYNI6WNTI=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR upgrades the cluster-api dependency to v1.2.12. Changelog [can be found here](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.2.12).

After this we should probably look into upgrading to at least cluster-api 1.3.x since the 1.2.x release will be considered EOL now that 1.4.x is out.

*Testing performed:*

make build / make test / deployed on testing management cluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->