### PR TITLE
Add tolerations to capc-controller-manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -47,3 +47,8 @@ spec:
             memory: 50Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
*Description of changes:*
Added tolerations to capc-controller-manager PodSpec that correspond to kubeadm control plane node taints. These tolerations are needed so the pod can be scheduled to the control plane node in case there is an attempt to drain and replace all worker nodes at once. Otherwise this pod will go into a pending state and the new workers will never come up and the old workers will never be deleted. 

Other providers such as Docker, VSphere, and Tinkerbell include these tolerations in their equivalent controller-managers:
- https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/commit/2bb31badfae022f4332df865f0856d8038824045
- https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/commit/e9c06d6c9ce3450b9c81eca2ae65fc8918d6ce92
- https://github.com/tinkerbell/cluster-api-provider-tinkerbell/blob/main/config/manager/manager.yaml#L49

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.