### PR TITLE
Tidy API objects and simplify webhook validation util

### DIFF
--- a/api/v1beta2/cloudstackaffinitygroup_types.go
+++ b/api/v1beta2/cloudstackaffinitygroup_types.go
@@ -20,9 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	AffinityGroupFinalizer = "affinitygroup.infrastructure.cluster.x-k8s.io"
-)
+const AffinityGroupFinalizer = "affinitygroup.infrastructure.cluster.x-k8s.io"
 
 // CloudStackAffinityGroupSpec defines the desired state of CloudStackAffinityGroup
 type CloudStackAffinityGroupSpec struct {

--- a/api/v1beta2/cloudstackcluster_types.go
+++ b/api/v1beta2/cloudstackcluster_types.go
@@ -38,7 +38,6 @@ type CloudStackClusterSpec struct {
 
 // The status of the CloudStackCluster object.
 type CloudStackClusterStatus struct {
-
 	// CAPI recognizes failure domains as a method to spread machines.
 	// CAPC sets failure domains to indicate functioning CloudStackFailureDomains.
 	// +optional

--- a/api/v1beta2/cloudstackcluster_webhook.go
+++ b/api/v1beta2/cloudstackcluster_webhook.go
@@ -102,9 +102,9 @@ func (r *CloudStackCluster) ValidateUpdate(old runtime.Object) error {
 	}
 
 	if oldSpec.ControlPlaneEndpoint.Host != "" { // Need to allow one time endpoint setting via CAPC cluster controller.
-		errorList = webhookutil.EnsureStringFieldsAreEqual(
+		errorList = webhookutil.EnsureEqualStrings(
 			spec.ControlPlaneEndpoint.Host, oldSpec.ControlPlaneEndpoint.Host, "controlplaneendpoint.host", errorList)
-		errorList = webhookutil.EnsureStringFieldsAreEqual(
+		errorList = webhookutil.EnsureEqualStrings(
 			string(spec.ControlPlaneEndpoint.Port), string(oldSpec.ControlPlaneEndpoint.Port),
 			"controlplaneendpoint.port", errorList)
 	}

--- a/api/v1beta2/cloudstackfailuredomain_types.go
+++ b/api/v1beta2/cloudstackfailuredomain_types.go
@@ -35,8 +35,11 @@ func FailureDomainHashedMetaName(fdName, clusterName string) string {
 const (
 	FailureDomainFinalizer = "cloudstackfailuredomain.infrastructure.cluster.x-k8s.io"
 	FailureDomainLabelName = "cloudstackfailuredomain.infrastructure.cluster.x-k8s.io/name"
-	NetworkTypeIsolated    = "Isolated"
-	NetworkTypeShared      = "Shared"
+)
+
+const (
+	NetworkTypeIsolated = "Isolated"
+	NetworkTypeShared   = "Shared"
 )
 
 type Network struct {

--- a/api/v1beta2/cloudstackisolatednetwork_types.go
+++ b/api/v1beta2/cloudstackisolatednetwork_types.go
@@ -21,10 +21,8 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-const (
-	// The presence of a finalizer prevents CAPI from deleting the corresponding CAPI data.
-	IsolatedNetworkFinalizer = "cloudstackisolatednetwork.infrastructure.cluster.x-k8s.io"
-)
+// The presence of a finalizer prevents CAPI from deleting the corresponding CAPI data.
+const IsolatedNetworkFinalizer = "cloudstackisolatednetwork.infrastructure.cluster.x-k8s.io"
 
 // CloudStackIsolatedNetworkSpec defines the desired state of CloudStackIsolatedNetwork
 type CloudStackIsolatedNetworkSpec struct {

--- a/api/v1beta2/cloudstackmachine_types.go
+++ b/api/v1beta2/cloudstackmachine_types.go
@@ -23,12 +23,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// The presence of a finalizer prevents CAPI from deleting the corresponding CAPI data.
+const MachineFinalizer = "cloudstackmachine.infrastructure.cluster.x-k8s.io"
+
 const (
-	// The presence of a finalizer prevents CAPI from deleting the corresponding CAPI data.
-	MachineFinalizer = "cloudstackmachine.infrastructure.cluster.x-k8s.io"
-	ProAffinity      = "pro"
-	AntiAffinity     = "anti"
-	NoAffinity       = "no"
+	ProAffinity  = "pro"
+	AntiAffinity = "anti"
+	NoAffinity   = "no"
 )
 
 // CloudStackMachineSpec defines the desired state of CloudStackMachine

--- a/api/v1beta2/cloudstackmachine_webhook.go
+++ b/api/v1beta2/cloudstackmachine_webhook.go
@@ -79,17 +79,20 @@ func (r *CloudStackMachine) ValidateUpdate(old runtime.Object) error {
 	}
 	oldSpec := oldMachine.Spec
 
-	errorList = webhookutil.EnsureBothFieldsAreEqual(r.Spec.Offering.ID, r.Spec.Offering.Name, oldSpec.Offering.ID, oldSpec.Offering.Name, "offering", errorList)
-	errorList = webhookutil.EnsureBothFieldsAreEqual(r.Spec.DiskOffering.ID, r.Spec.DiskOffering.Name, oldSpec.DiskOffering.ID, oldSpec.DiskOffering.Name, "diskOffering", errorList)
+	errorList = webhookutil.EnsureEqualStrings(r.Spec.Offering.ID, oldSpec.Offering.ID, "offering", errorList)
+	errorList = webhookutil.EnsureEqualStrings(r.Spec.Offering.Name, oldSpec.Offering.Name, "offering", errorList)
+	errorList = webhookutil.EnsureEqualStrings(r.Spec.DiskOffering.ID, oldSpec.DiskOffering.ID, "diskOffering", errorList)
+	errorList = webhookutil.EnsureEqualStrings(r.Spec.DiskOffering.Name, oldSpec.DiskOffering.Name, "diskOffering", errorList)
 	errorList = webhookutil.EnsureIntFieldsAreNotNegative(r.Spec.DiskOffering.CustomSize, "customSizeInGB", errorList)
-	errorList = webhookutil.EnsureStringFieldsAreEqual(r.Spec.DiskOffering.MountPath, oldSpec.DiskOffering.MountPath, "mountPath", errorList)
-	errorList = webhookutil.EnsureStringFieldsAreEqual(r.Spec.DiskOffering.Device, oldSpec.DiskOffering.Device, "device", errorList)
-	errorList = webhookutil.EnsureStringFieldsAreEqual(r.Spec.DiskOffering.Filesystem, oldSpec.DiskOffering.Filesystem, "filesystem", errorList)
-	errorList = webhookutil.EnsureStringFieldsAreEqual(r.Spec.DiskOffering.Label, oldSpec.DiskOffering.Label, "label", errorList)
-	errorList = webhookutil.EnsureStringFieldsAreEqual(r.Spec.SSHKey, oldSpec.SSHKey, "sshkey", errorList)
-	errorList = webhookutil.EnsureBothFieldsAreEqual(r.Spec.Template.ID, r.Spec.Template.Name, oldSpec.Template.ID, oldSpec.Template.Name, "template", errorList)
-	errorList = webhookutil.EnsureStringStringMapFieldsAreEqual(&r.Spec.Details, &oldSpec.Details, "details", errorList)
-	errorList = webhookutil.EnsureStringFieldsAreEqual(r.Spec.Affinity, oldSpec.Affinity, "affinity", errorList)
+	errorList = webhookutil.EnsureEqualStrings(r.Spec.DiskOffering.MountPath, oldSpec.DiskOffering.MountPath, "mountPath", errorList)
+	errorList = webhookutil.EnsureEqualStrings(r.Spec.DiskOffering.Device, oldSpec.DiskOffering.Device, "device", errorList)
+	errorList = webhookutil.EnsureEqualStrings(r.Spec.DiskOffering.Filesystem, oldSpec.DiskOffering.Filesystem, "filesystem", errorList)
+	errorList = webhookutil.EnsureEqualStrings(r.Spec.DiskOffering.Label, oldSpec.DiskOffering.Label, "label", errorList)
+	errorList = webhookutil.EnsureEqualStrings(r.Spec.SSHKey, oldSpec.SSHKey, "sshkey", errorList)
+	errorList = webhookutil.EnsureEqualStrings(r.Spec.Template.ID, oldSpec.Template.ID, "template", errorList)
+	errorList = webhookutil.EnsureEqualStrings(r.Spec.Template.Name, oldSpec.Template.Name, "template", errorList)
+	errorList = webhookutil.EnsureEqualMapStringString(&r.Spec.Details, &oldSpec.Details, "details", errorList)
+	errorList = webhookutil.EnsureEqualStrings(r.Spec.Affinity, oldSpec.Affinity, "affinity", errorList)
 
 	if !reflect.DeepEqual(r.Spec.AffinityGroupIDs, oldSpec.AffinityGroupIDs) { // Equivalent to other Ensure funcs.
 		errorList = append(errorList, field.Forbidden(field.NewPath("spec", "AffinityGroupIDs"), "AffinityGroupIDs"))

--- a/api/v1beta2/cloudstackmachinestatechecker_types.go
+++ b/api/v1beta2/cloudstackmachinestatechecker_types.go
@@ -16,9 +16,7 @@ limitations under the License.
 
 package v1beta2
 
-import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // CloudStackMachineStateCheckerSpec
 type CloudStackMachineStateCheckerSpec struct {

--- a/api/v1beta2/cloudstackmachinetemplate_types.go
+++ b/api/v1beta2/cloudstackmachinetemplate_types.go
@@ -16,9 +16,7 @@ limitations under the License.
 
 package v1beta2
 
-import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 type CloudStackMachineTemplateResource struct {
 	// Standard object's metadata.

--- a/pkg/webhookutil/webhook_validators.go
+++ b/pkg/webhookutil/webhook_validators.go
@@ -38,7 +38,7 @@ func EnsureAtLeastOneFieldExists(value1 string, value2 string, name string, allE
 	return allErrs
 }
 
-func EnsureStringFieldsAreEqual(new string, old string, name string, allErrs field.ErrorList) field.ErrorList {
+func EnsureEqualStrings(new string, old string, name string, allErrs field.ErrorList) field.ErrorList {
 	if new != old {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", name), name))
 	}
@@ -52,14 +52,7 @@ func EnsureIntFieldsAreNotNegative(new int64, name string, allErrs field.ErrorLi
 	return allErrs
 }
 
-func EnsureBothFieldsAreEqual(new1 string, new2 string, old1 string, old2 string, name string, allErrs field.ErrorList) field.ErrorList {
-	if new1 != old1 || new2 != old2 {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", name), name))
-	}
-	return allErrs
-}
-
-func EnsureStringStringMapFieldsAreEqual(new *map[string]string, old *map[string]string, name string, allErrs field.ErrorList) field.ErrorList {
+func EnsureEqualMapStringString(new *map[string]string, old *map[string]string, name string, allErrs field.ErrorList) field.ErrorList {
 	if old == nil && new == nil {
 		return allErrs
 	}


### PR DESCRIPTION
## Summary

This PR does some minor tidy up around API objects, comments and grouping of consts and simplifies the `/pkg/webhookutil` package API.