### PR TITLE
Makefile: fix 'make tilt-up'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ docker-push: .dockerflag.mk ## Push docker image with the manager.
 ## --------------------------------------
 
 .PHONY: tilt-up
-tilt-up: cluster-api kind-cluster cluster-api/tilt-settings.json manifests ## Setup and run tilt for development.
+tilt-up: cluster-api kind-cluster cluster-api/tilt-settings.json generate-manifests ## Setup and run tilt for development.
 	cd cluster-api && tilt up
 
 .PHONY: kind-cluster


### PR DESCRIPTION
*Issue #, if available:*

This fixes the issue when run "make tilt-up" which fails with error "make: *** No rule to make target 'manifests', needed by 'tilt-up'.  Stop."

*Description of changes:*

this has been changed in c3377bcf5a3beb74b462f0244a6c160b95981c44
but reverted in 3543c69e5c574aeeaf0e03ed7823d9bc168a6d43

*Testing performed:*

"make tilt-up" works well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->