### PR TITLE
tilt: increase memory limit to fix exit code 137 if debugging is enabled

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,7 +41,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 100Mi
+            memory: 200Mi
           requests:
             cpu: 100m
             memory: 50Mi


### PR DESCRIPTION
*Issue #, if available:*

With #236 and #238, I am able to run tilt with debugging. However, the capc-controller is not started successfully, with exit code 137.

http://localhost:10350/r/capc_controller/overview shows

```
    [event: pod capc-system/capc-controller-manager-65f6f5c5b5-426hj] Pulling image "localhost:5000/cluster-api-provider-cloudstack:tilt-74529ec3c4b48990"
    [event: pod capc-system/capc-controller-manager-65f6f5c5b5-426hj] Successfully pulled image "localhost:5000/cluster-api-provider-cloudstack:tilt-74529ec3c4b48990" in 1.175550197s (1.175558459s including waiting)
    API server listening at: [::]:30000
    2023-05-05T16:51:20Z warning layer=rpc Listening for remote connections (connections are not authenticated nor encrypted)
    Killed
    Exiting with code 137
```

*Description of changes:*

This issue is fixed by increasing the memory limit from 100Mi to 200Mi.

*Testing performed:*

`make tilt-up` work and capc-controller runs well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->