### PR TITLE
e2e: set imageRepository to "" in yaml files

### DIFF
--- a/test/e2e/data/infrastructure-cloudstack/v1beta1/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta1/bases/cluster-with-kcp.yaml
@@ -43,7 +43,7 @@ spec:
         kubeletExtraArgs:
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
     clusterConfiguration:
-      imageRepository: registry.k8s.io
+      imageRepository: ""
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta1/cluster-template-custom-disk-offering/cluster-with-custom-disk-offering.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta1/cluster-template-custom-disk-offering/cluster-with-custom-disk-offering.yaml
@@ -10,7 +10,7 @@ spec:
         kubeletExtraArgs:
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
     clusterConfiguration:
-      imageRepository: registry.k8s.io
+      imageRepository: ""
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta1/cluster-template-disk-offering/cluster-with-disk-offering.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta1/cluster-template-disk-offering/cluster-with-disk-offering.yaml
@@ -10,7 +10,7 @@ spec:
         kubeletExtraArgs:
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
     clusterConfiguration:
-      imageRepository: registry.k8s.io
+      imageRepository: ""
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta1/cluster-template-shared-network-kubevip/cluster-with-shared-network-and-kubevip.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta1/cluster-template-shared-network-kubevip/cluster-with-shared-network-and-kubevip.yaml
@@ -43,7 +43,7 @@ spec:
         kubeletExtraArgs:
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
     clusterConfiguration:
-      imageRepository: registry.k8s.io
+      imageRepository: ""
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/bases/cluster-with-kcp.yaml
@@ -48,7 +48,7 @@ spec:
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
     clusterConfiguration:
-      imageRepository: registry.k8s.io
+      imageRepository: ""
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-custom-disk-offering/cluster-with-custom-disk-offering.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-custom-disk-offering/cluster-with-custom-disk-offering.yaml
@@ -10,7 +10,7 @@ spec:
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
     clusterConfiguration:
-      imageRepository: registry.k8s.io
+      imageRepository: ""
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-disk-offering/cluster-with-disk-offering.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-disk-offering/cluster-with-disk-offering.yaml
@@ -10,7 +10,7 @@ spec:
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
     clusterConfiguration:
-      imageRepository: registry.k8s.io
+      imageRepository: ""
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-after/upgrade-cp.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-after/upgrade-cp.yaml
@@ -10,7 +10,7 @@ spec:
         kubeletExtraArgs:
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
     clusterConfiguration:
-      imageRepository: registry.k8s.io
+      imageRepository: ""
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-before/before.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-kubernetes-version-upgrade-before/before.yaml
@@ -10,7 +10,7 @@ spec:
         kubeletExtraArgs:
           provider-id: cloudstack:///'{{ ds.meta_data.instance_id }}'
     clusterConfiguration:
-      imageRepository: registry.k8s.io
+      imageRepository: ""
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'

--- a/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-shared-network-kubevip/cluster-with-shared-network-and-kubevip.yaml
+++ b/test/e2e/data/infrastructure-cloudstack/v1beta2/cluster-template-shared-network-kubevip/cluster-with-shared-network-and-kubevip.yaml
@@ -48,7 +48,7 @@ spec:
         kubeletExtraArgs:
           provider-id: "cloudstack:///'{{ ds.meta_data.instance_id }}'"
     clusterConfiguration:
-      imageRepository: registry.k8s.io
+      imageRepository: ""
     joinConfiguration:
       nodeRegistration:
         name: '{{ local_hostname }}'


### PR DESCRIPTION
*Issue #, if available:*

The image repository has been changed to registry.k8s.io by commit 8c1e6144bce2dc640eb5fc6597c37d93d8ac9362

However, with registry.k8s.io, the control plane vm cannot be booted to Ready state due to error below
```
    ubuntu@disk-offering-gzojvb-control-plane-gwbnt:~$ tail -f /var/log/cloud-init-output.log
    [2023-05-08 11:09:23] [preflight] You can also perform this action in beforehand using 'kubeadm config images pull'
    [2023-05-08 11:09:28] error execution phase preflight: [preflight] Some fatal errors occurred:
    [2023-05-08 11:09:28]   [ERROR ImagePull]: failed to pull image registry.k8s.io/coredns:v1.8.4: output: time="2023-05-08T11:09:28Z" level=fatal msg="pulling image: rpc error: code = NotFound desc = failed to pull and unpack image \"registry.k8s.io/coredns:v1.8.4\": failed to resolve reference \"registry.k8s.io/coredns:v1.8.4\": registry.k8s.io/coredns:v1.8.4: not found"
    [2023-05-08 11:09:28] , error: exit status 1
```

this is same as https://github.com/kubernetes/kubeadm/issues/2761 
The new registry should be supported in k8s 1.25+. However, we still use 1.22/1.23/1.24 templates, so we need to use k8s.gcr.io

*Description of changes:*

setting the image respository to "" so that capi/kubeadm will determine the default repository by kubernetes version.

*Testing performed:*

e2e tests look ok now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->