### PR TITLE
Fix panic on machine controller when considering affinity

### DIFF
--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -128,7 +128,7 @@ func (r *CloudStackMachineReconciliationRunner) Reconcile() (retRes ctrl.Result,
 	)
 }
 
-// ConsiderAffinity sets machine affinity if needed. It also creates or gets an affinity group CRD if required and
+// ConsiderAffinity sets machine affinity if needed. It also creates or gets an affinity group resource if required and
 // checks it for readiness.
 func (r *CloudStackMachineReconciliationRunner) ConsiderAffinity() (ctrl.Result, error) {
 	if r.ReconciliationSubject.Spec.Affinity == infrav1.NoAffinity ||
@@ -138,7 +138,8 @@ func (r *CloudStackMachineReconciliationRunner) ConsiderAffinity() (ctrl.Result,
 
 	agName, err := utils.GenerateAffinityGroupName(*r.ReconciliationSubject, r.CAPIMachine)
 	if err != nil {
-		r.Log.Info("getting affinity group name", err)
+		r.Log.Info("getting affinity group name", err.Error())
+		return ctrl.Result{}, err
 	}
 
 	// Set failure domain name and owners.


### PR DESCRIPTION
*Issue #, if available:*
#244

*Description of changes:*
Cloudstack machine controller supports creating and managing affinity groups. When the controller tries to generate an affinity group name it uses the owner ref of the CAPI machine object to identify node role and uses those owner ref to generate the AG group name. Controller only supports and expects CAPI machine to be owned by KCP, Etcdadm or MachineSet. If a CAPI machine is owned by CAPI cluster (some cases with etcd machine), this flow fails and results in an error. A bug with the logging causes panic. These changes fixes the panic for now.

Future scope on how to streamline the process to identify node roles without depending on CAPI machine's owner ref directly is discussed [here](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/issues/240)

*Testing performed:*
Tested by removing ownerRef and monitoring if CAPC crashes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->