### PR TITLE
e2e: fix disk_offering_test.go

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -512,7 +512,17 @@ func CheckDiskOfferingOfVmInstances(client *cloudstack.CloudStackClient, cluster
 	}
 	for _, vm := range listResp.VirtualMachines {
 		if strings.Contains(vm.Name, clusterName) {
-			Expect(vm.Diskofferingname).To(Equal(diskOfferingName))
+			p := client.Volume.NewListVolumesParams()
+			p.SetVirtualmachineid(vm.Id)
+			volResp, err := client.Volume.ListVolumes(p)
+			if err != nil {
+				Fail(fmt.Sprintf("Failed to list volumes for VM instance %s", vm.Id))
+			}
+			for _, vol := range volResp.Volumes {
+				if strings.Contains(vol.Name, DataVolumePrefix) {
+					Expect(vol.Diskofferingname).To(Equal(diskOfferingName))
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Got the following error when run e2e test /test/e2e/disk_offering.go
```
    • [FAILED] [292.946 seconds]
    When testing with disk offering [It] Should successfully create a cluster with disk offering
    /data/git/cluster-api-provider-cloudstack/test/e2e/disk_offering.go:60

    [FAILED] Expected
        <string>:
    to equal
        <string>: Small
    In [It] at: /data/git/cluster-api-provider-cloudstack/test/e2e/common.go:515
```

The error is because diskofferingname of VM is not the offering name of DATA disks. It is the offering name of ROOT disk only when the VM is created from ISO.

The test passes if check the offering name of DATA disks instead.

*Testing performed:*

```
Ran 2 of 29 Specs in 722.485 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 27 Skipped
PASS
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->