### PR TITLE
Fix userdata compression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,8 @@ config/.flag-test.mk: $(CONTROLLER_GEN) $(MANIFEST_GEN_INPUTS_TEST)
 	@touch config/.flag-test.mk
 
 .PHONY: test
-test: generate-deepcopy-test generate-manifest-test generate-mocks lint $(GINKGO_V2) $(KUBECTL) $(API_SERVER) $(ETCD) ## Run tests. At the moment this is only unit tests.
+test: ## Run tests.
+test: generate-deepcopy-test generate-manifest-test generate-mocks lint $(GINKGO_V2) $(KUBECTL) $(API_SERVER) $(ETCD)
 	@./hack/testing_ginkgo_recover_statements.sh --add # Add ginkgo.GinkgoRecover() statements to controllers.
 	@# The following is a slightly funky way to make sure the ginkgo statements are removed regardless the test results.
 	@$(GINKGO_V2) --label-filter="!integ" --cover -coverprofile cover.out --covermode=atomic -v ./api/... ./controllers/... ./pkg/...; EXIT_STATUS=$$?;\

--- a/api/v1beta2/cloudstackmachine_types.go
+++ b/api/v1beta2/cloudstackmachine_types.go
@@ -92,6 +92,10 @@ type CloudStackMachineSpec struct {
 	UncompressedUserData *bool `json:"uncompressedUserData,omitempty"`
 }
 
+func (c *CloudStackMachine) CompressUserdata() bool {
+	return c.Spec.UncompressedUserData == nil || !*c.Spec.UncompressedUserData
+}
+
 type CloudStackResourceIdentifier struct {
 	// Cloudstack resource ID.
 	// +optional

--- a/api/v1beta2/cloudstackmachine_types_test.go
+++ b/api/v1beta2/cloudstackmachine_types_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2_test
+
+import (
+	"k8s.io/utils/pointer"
+	capcv1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta2"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CloudStackMachineConfig_CompressUserdata", func() {
+	for _, tc := range []struct {
+		Name    string
+		Machine capcv1.CloudStackMachine
+		Expect  bool
+	}{
+		{
+			Name: "is true when uncompressed user data is nil",
+			Machine: capcv1.CloudStackMachine{
+				Spec: capcv1.CloudStackMachineSpec{
+					UncompressedUserData: nil,
+				},
+			},
+			Expect: true,
+		},
+		{
+			Name: "is false when uncompressed user data is true",
+			Machine: capcv1.CloudStackMachine{
+				Spec: capcv1.CloudStackMachineSpec{
+					UncompressedUserData: pointer.Bool(true),
+				},
+			},
+			Expect: false,
+		},
+		{
+			Name: "Is false when uncompressed user data is false",
+			Machine: capcv1.CloudStackMachine{
+				Spec: capcv1.CloudStackMachineSpec{
+					UncompressedUserData: pointer.Bool(false),
+				},
+			},
+			Expect: true,
+		},
+	} {
+		tc := tc
+		It(tc.Name, func() {
+			result := tc.Machine.CompressUserdata()
+			Expect(result).To(Equal(tc.Expect))
+		})
+	}
+})

--- a/pkg/cloud/helpers.go
+++ b/pkg/cloud/helpers.go
@@ -18,7 +18,7 @@ package cloud
 
 import (
 	"bytes"
-	"compress/gzip"
+	cgzip "compress/gzip"
 )
 
 type set func(string)
@@ -43,13 +43,13 @@ func setIntIfPositive(num int64, setFn setInt) {
 	}
 }
 
-func CompressString(str string) (string, error) {
-	buf := &bytes.Buffer{}
-	gzipWriter := gzip.NewWriter(buf)
-	if _, err := gzipWriter.Write([]byte(str)); err != nil {
+func compress(str string) (string, error) {
+	var buf bytes.Buffer
+	w := cgzip.NewWriter(&buf)
+	if _, err := w.Write([]byte(str)); err != nil {
 		return "", err
 	}
-	if err := gzipWriter.Close(); err != nil {
+	if err := w.Close(); err != nil {
 		return "", err
 	}
 	return buf.String(), nil

--- a/pkg/cloud/helpers_test.go
+++ b/pkg/cloud/helpers_test.go
@@ -24,26 +24,9 @@ import (
 	"reflect"
 
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
-	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 )
-
-var _ = Describe("Helpers", func() {
-
-	It("should compress and encode string", func() {
-		str := "Hello World"
-
-		compressedData, err := cloud.CompressString(str)
-
-		reader, _ := gzip.NewReader(bytes.NewReader([]byte(compressedData)))
-		result, _ := io.ReadAll(reader)
-
-		Ω(err).Should(BeNil())
-		Ω(string(result)).Should(Equal(str))
-	})
-})
 
 // This matcher is used to make gomega matching compatible with gomock parameter matching.
 // It's pretty awesome!
@@ -91,9 +74,16 @@ func FieldMatcherGenerator(fetchFunc string) func(string) types.GomegaMatcher {
 	}
 }
 
-var (
-	DomainIDEquals = FieldMatcherGenerator("GetDomainid")
-	AccountEquals  = FieldMatcherGenerator("GetAccount")
-	IDEquals       = FieldMatcherGenerator("GetId")
-	NameEquals     = FieldMatcherGenerator("GetName")
-)
+var NameEquals = FieldMatcherGenerator("GetName")
+
+func decompress(data []byte) ([]byte, error) {
+	reader, err := gzip.NewReader(bytes.NewBuffer(data))
+	if err != nil {
+		return nil, err
+	}
+	data, err = io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}


### PR DESCRIPTION
# Summary

When the UncompressedUserData field is nil on CloudStackMachine instances CAPC is interpreting it as true.

This reworks the compression decision logic to give a nil UncompressedUserData the same semantics as false.
