### PR TITLE
e2e: fix two_clusters.go if there are multiple users under ROOT/admin

### DIFF
--- a/pkg/cloud/user_credentials.go
+++ b/pkg/cloud/user_credentials.go
@@ -164,6 +164,7 @@ func (c *client) ResolveUser(user *User) error {
 	p.SetAccount(user.Account.Name)
 	p.SetDomainid(user.Domain.ID)
 	p.SetListall(true)
+	setIfNotEmpty(user.ID, p.SetId)
 	resp, err := c.cs.User.ListUsers(p)
 	if err != nil {
 		c.customMetrics.EvaluateErrorAndIncrementAcsReconciliationErrorCounter(err)


### PR DESCRIPTION
*Issue #, if available:*

When there are multiple users under account ROOT/admin, the e2e test two_clusters.go fails with error
"could not find sufficient user (with API keys) in domain/account ROOT/admin"


*Description of changes:*

The issue is fixed by setting the user ID if it exists.


*Testing performed:*

The following test passes

```
JOB='"should successfully add and remove a second cluster without breaking the first cluster"' make run-e2e 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->