### PR TITLE
Makefile: ensure kind before running e2e smoke test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,7 @@ run-e2e: e2e-essentials ## Run e2e testing. JOB is an optional REGEXP to select 
 	kind delete clusters capi-test
 
 run-e2e-smoke:
+	hack/ensure-kind.sh
 	JOB="\"CAPC E2E SMOKE TEST\"" $(MAKE) run-e2e
 
 ##@ Cleanup

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GOPATH_BIN="$(go env GOPATH)/bin/"
+MINIMUM_KIND_VERSION=v0.14.0
+GOARCH="$(go env GOARCH)"
+GOOS="$(go env GOOS)"
+
+# Ensure the kind tool exists and is a viable version, or installs it
+verify_kind_version() {
+
+  # If kind is not available on the path, get it
+  if ! [ -x "$(command -v kind)" ]; then
+    if [ "$GOOS" == "linux" ] || [ "$GOOS" == "darwin" ]; then
+      echo 'kind not found, installing'
+      if ! [ -d "${GOPATH_BIN}" ]; then
+        mkdir -p "${GOPATH_BIN}"
+      fi
+      curl -sLo "${GOPATH_BIN}/kind" "https://github.com/kubernetes-sigs/kind/releases/download/${MINIMUM_KIND_VERSION}/kind-${GOOS}-${GOARCH}"
+      chmod +x "${GOPATH_BIN}/kind"
+    else
+      echo "Missing required binary in path: kind"
+      return 2
+    fi
+  fi
+
+  local kind_version
+  kind_version="v$(kind version -q)"
+  if [[ "${MINIMUM_KIND_VERSION}" != $(echo -e "${MINIMUM_KIND_VERSION}\n${kind_version}" | sort -s -t. -k 1,1n -k 2,2n -k 3,3n | head -n1) ]]; then
+    cat <<EOF
+Detected kind version: ${kind_version}.
+Requires ${MINIMUM_KIND_VERSION} or greater.
+Please install ${MINIMUM_KIND_VERSION} or later.
+EOF
+    return 2
+  fi
+}
+
+verify_kind_version


### PR DESCRIPTION
*Issue #, if available:*

e2e smoke test for PRs failed with error below
```
./cluster-api/hack/kind-install-for-capd.sh: line 42: kind: command not found
make[1]: *** [Makefile:237: kind-cluster] Error 127
make[1]: Leaving directory '/home/prow/go/src/github.com/kubernetes-sigs/cluster-api-provider-cloudstack'
make: *** [Makefile:295: run-e2e-smoke] Error 2
```

*Description of changes:*

ensure kind is installed before running e2e tests
(The hack/ensure-go.sh is being used by other cluster-api providers)

*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->