### PR TITLE
Makefile/e2e: ensure cloud-config.yaml exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,9 @@ run-e2e: e2e-essentials ## Run e2e testing. JOB is an optional REGEXP to select 
 	    -e2e.artifacts-folder=${REPO_ROOT}/_artifacts \
 	    -e2e.config=${E2E_CONFIG} \
 	    -e2e.skip-resource-cleanup=false -e2e.use-existing-cluster=true
+	EXIT_STATUS=$$?
 	kind delete clusters capi-test
+	exit $$EXIT_STATUS
 
 run-e2e-smoke:
 	./hack/ensure-kind.sh

--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,8 @@ run-e2e: e2e-essentials ## Run e2e testing. JOB is an optional REGEXP to select 
 	kind delete clusters capi-test
 
 run-e2e-smoke:
-	hack/ensure-kind.sh
+	./hack/ensure-kind.sh
+	./hack/ensure-cloud-config-yaml.sh
 	JOB="\"CAPC E2E SMOKE TEST\"" $(MAKE) run-e2e
 
 ##@ Cleanup

--- a/hack/ensure-cloud-config-yaml.sh
+++ b/hack/ensure-cloud-config-yaml.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This ensures that cloud-config.yaml exists which is required for e2e smoke test
+if [ ! -f "cloud-config.yaml" ];then
+    echo "cloud-config.yaml is not found, creating"
+    cat >cloud-config.yaml <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret1
+  namespace: default
+type: Opaque
+stringData:
+  api-key: XXXX
+  secret-key: XXXX
+  api-url: http://1.2.3.4:8080/client/api
+  verify-ssl: "false"
+EOF
+
+fi


### PR DESCRIPTION
*Issue #, if available:*

Although the test "capi-provider-cloudstack-presubmit-e2e-smoke-test" passed for PR #260 , the e2e smoke test is not actually run. It terminated due to error
```
error: the path "cloud-config.yaml" does not exist
```
see logs at https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-cloudstack/260/capi-provider-cloudstack-presubmit-e2e-smoke-test/1663960843286482944

*Description of changes:*

This PR ensures cloud-config.yaml exists when run e2e smoke test. It creates a dummy file if cloud-config.yaml does not exist.

*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->