### PR TITLE
e2e: restore secret name to original while running tests with ToxiProxy

### DIFF
--- a/test/e2e/toxiproxy/toxiProxy.go
+++ b/test/e2e/toxiproxy/toxiProxy.go
@@ -203,11 +203,13 @@ func SetupForToxiProxyTestingACS(ctx context.Context, clusterName string, cluste
 	Expect(err).To(BeNil())
 
 	// Override the test config to use this alternate cloud-config secret
+	originalSecretName := e2eConfig.GetVariable("CLOUDSTACK_FD1_SECRET_NAME")
 	e2eConfig.Variables["CLOUDSTACK_FD1_SECRET_NAME"] = toxiProxyFdEndpointSecret.Name
 
 	// Overriding e2e config file into a new temp copy, so as not to inadvertently override the other e2e tests.
 	newConfigFilePath := fmt.Sprintf("/tmp/%v.yaml", toxiProxyName)
 	editConfigFile(newConfigFilePath, configPath, "CLOUDSTACK_FD1_SECRET_NAME", toxiProxyFdEndpointSecret.Name)
+	e2eConfig.Variables["CLOUDSTACK_FD1_SECRET_NAME"] = originalSecretName
 
 	// Return a context
 	return &Context{


### PR DESCRIPTION
*Issue #, if available:*

The e2e test network_interruption_toxi.go failed with message below

```
09:09:18   ␛[91mExpected
09:09:18       <*errors.StatusError | 0xc00095b9a0>: {
09:09:18           ErrStatus: {
09:09:18               TypeMeta: {Kind: "", APIVersion: ""},
09:09:18               ListMeta: {
09:09:18                   SelfLink: "",
09:09:18                   ResourceVersion: "",
09:09:18                   Continue: "",
09:09:18                   RemainingItemCount: nil,
09:09:18               },
09:09:18               Status: "Failure",
09:09:18               Message: "secrets \"secret1-toxiproxy\" not found",
09:09:18               Reason: "NotFound",
09:09:18               Details: {
09:09:18                   Name: "secret1-toxiproxy",
09:09:18                   Group: "",
09:09:18                   Kind: "secrets",
09:09:18                   UID: "",
09:09:18                   Causes: nil,
09:09:18                   RetryAfterSeconds: 0,
09:09:18               },
09:09:18               Code: 404,
09:09:18           },
09:09:18       }
09:09:18   to be nil␛[0m
```
The issue is because the default secretname has been updated to secret1-toxiproxy in deploy_app_toxi.go.
This happened with deploy_app_toxi.go sometimes, if network_interruption_toxi.go is run before it.

*Description of changes:*


Issue should be fixed by restoring secret name to original

*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->