### PR TITLE
Disable CGO when running generate deep copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ DEEPCOPY_GEN_INPUTS=$(shell find ./api -name "*test*" -prune -o -name "*zz_gener
 .PHONY: generate-deepcopy
 generate-deepcopy: $(DEEPCOPY_GEN_TARGETS) ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 api/%/zz_generated.deepcopy.go: $(CONTROLLER_GEN) $(DEEPCOPY_GEN_INPUTS)
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	CGO_ENABLED=0 $(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 MANIFEST_GEN_INPUTS=$(shell find ./api ./controllers -type f -name "*test*" -prune -o -name "*zz_generated*" -prune -o -print)
 # Using a flag file here as config output is too complicated to be a target.


### PR DESCRIPTION

*Issue #, if available:* 
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/issues/266

*Description of changes:*
This should fix the job that periodically builds images, since the container where the releas staging target is run doesn't have gcc installed.

*Testing performed:*
Ran `make generate-deepcopy` inside `gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e` and verified it works.

Inspiration from https://github.com/kubernetes-sigs/cluster-api/issues/6230


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->