### PR TITLE
Makefile: Fix release-templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,8 @@ release-alias-tag: # Adds the tag to the last build tag.
 	gcloud container images add-tag -q $(CONTROLLER_IMG):$(TAG) $(CONTROLLER_IMG):$(RELEASE_ALIAS_TAG)
 
 .PHONY: release-templates
-release-templates: $(RELEASE_DIR) ## Generate release templates
+release-templates: ## Generate release templates
+	@mkdir -p $(RELEASE_DIR)
 	cp templates/cluster-template*.yaml $(RELEASE_DIR)/
 
 .PHONY: upload-staging-artifacts

--- a/Makefile
+++ b/Makefile
@@ -310,6 +310,7 @@ clean: ## Cleans up everything.
 	rm -rf $(TOOLS_BIN_DIR)
 	rm -rf cluster-api
 	rm -rf test/e2e/data/infrastructure-cloudstack/*/*yaml
+	rm -rf config/.flag.mk config/.flag-test.mk .dockerflag.mk
 
 ##@ Release
 ## --------------------------------------


### PR DESCRIPTION
*Issue #, if available:*

fixes #266 

the job fails with the latest steps.
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-cluster-api-provider-cloudstack-push-images/1666900501939097600
```
make[1]: *** No rule to make target 'out', needed by 'release-templates'.  Stop.
make: *** [Makefile:335: release-staging] Error 2
```

*Description of changes:*

create the release dir (./out) if not exist

*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->