### PR TITLE
Add missing release dir target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,13 +316,15 @@ clean: ## Cleans up everything.
 ## Release
 ## --------------------------------------
 
+$(RELEASE_DIR):
+	@mkdir -p $(RELEASE_DIR)
+
 .PHONY: release-manifests
 RELEASE_MANIFEST_TARGETS=$(RELEASE_DIR)/infrastructure-components.yaml $(RELEASE_DIR)/metadata.yaml
 RELEASE_MANIFEST_INPUTS=$(KUSTOMIZE) config/.flag.mk $(shell find config)
 RELEASE_MANIFEST_SOURCE_BASE ?= config/default
 release-manifests: $(RELEASE_MANIFEST_TARGETS) ## Create kustomized release manifest in $RELEASE_DIR (defaults to out).
-$(RELEASE_DIR)/%: $(RELEASE_MANIFEST_INPUTS)
-	@mkdir -p $(RELEASE_DIR)
+$(RELEASE_DIR)/%: $(RELEASE_DIR) $(RELEASE_MANIFEST_INPUTS)
 	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
 	$(KUSTOMIZE) build $(RELEASE_MANIFEST_SOURCE_BASE) > $(RELEASE_DIR)/infrastructure-components.yaml
 


### PR DESCRIPTION
*Issue #, if available:*
Follow up fix for https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/issues/266 after the original issue with gcc was fixed, this was uncovered.

*Description of changes:*
If release-templates was run before other targets, make failed since there wasn't any target for release dir.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ --