### PR TITLE
e2e: Decrease network interruption time for toxiproxy test

### DIFF
--- a/test/e2e/network_interruption_toxi.go
+++ b/test/e2e/network_interruption_toxi.go
@@ -127,7 +127,7 @@ func NetworkInterruptionToxiSpec(ctx context.Context, inputGetter func() CommonS
 }
 
 func networkInterruptor(toxiProxyContext *toxiproxy.Context, shutdownChannel chan bool) {
-	for {	
+	for {
 		// Wait for ApplyClusterTemplateAndWait() to make some progress
 		helpers.InterruptibleSleep(15*time.Second, time.Second, shutdownChannel)
 
@@ -135,7 +135,7 @@ func networkInterruptor(toxiProxyContext *toxiproxy.Context, shutdownChannel cha
 		toxiProxyContext.Disable()
 
 		// Leave the network disabled for some period of time
-		helpers.InterruptibleSleep(30*time.Second, time.Second, shutdownChannel)
+		helpers.InterruptibleSleep(15*time.Second, time.Second, shutdownChannel)
 
 		// Restore communications to ACS
 		toxiProxyContext.Enable()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As of now, e2e tests for ToxiProxy fail intermittently. Because sometimes due to network interruption, it takes some extra time for different resources to become available. Decreasing the time for network interruption fixes that.
*Testing performed:*
I tested two changes:
1. Decreasing the network interruption time
2. Increase the wait time for different resources (cluster, controller, control-plane, etc.) to become ready

With both the changes, the tests were always passing. I ran a couple of tests with these changes separately and tests were always passing. I am decreasing the interruption, since increasing the wait time also increased the duration of the tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->