### PR TITLE
E2e increase wait time

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -22,9 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -212,7 +212,7 @@ func DownloadFromAppInWorkloadCluster(ctx context.Context, workloadKubeconfigPat
 	if err != nil {
 		return result, err
 	}
-	numRetries := 3
+	numRetries := 10
 	for result == "" && numRetries > 0 {
 		// A single retry to accommodate occasional cases where an empty string is returned, ostensibly
 		//  because the service isn't fully ready.  Subsequent requests have always worked.

--- a/test/e2e/config/cloudstack.yaml
+++ b/test/e2e/config/cloudstack.yaml
@@ -166,9 +166,9 @@ intervals:
 
   default/wait-errors: ["5m", "10s"]
   default/wait-controllers: ["5m", "10s"]
-  default/wait-cluster: ["5m", "10s"]
-  default/wait-control-plane: ["20m", "10s"]
-  default/wait-worker-nodes: ["20m", "10s"]
+  default/wait-cluster: ["10m", "10s"]
+  default/wait-control-plane: ["25m", "10s"]
+  default/wait-worker-nodes: ["25m", "10s"]
   default/wait-delete-cluster: ["20m", "10s"]
   default/wait-machine-remediation: ["20m", "10s"]
   default/wait-machine-upgrade: ["20m", "10s"]
@@ -176,5 +176,3 @@ intervals:
   node-drain/wait-deployment-available: ["3m", "10s"]
   node-drain/wait-control-plane: ["15m", "10s"]
   node-drain/wait-machine-deleted: ["5m", "10s"]
-
-


### PR DESCRIPTION
*Issue #, if available:*
Tests fail intermittently because the cluster/control plane is not ready or the service is not ready for deployment
*Description of changes:*
Increase wait time & retries
*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->