### PR TITLE
Fix affinity group naming

### DIFF
--- a/controllers/utils/affinity_group.go
+++ b/controllers/utils/affinity_group.go
@@ -89,7 +89,7 @@ func (r *ReconciliationRunner) GetOrCreateAffinityGroup(
 }
 
 // The computed affinity group name relevant to this machine.
-func GenerateAffinityGroupName(csm infrav1.CloudStackMachine, capiMachine *clusterv1.Machine) (string, error) {
+func GenerateAffinityGroupName(csm infrav1.CloudStackMachine, capiMachine *clusterv1.Machine, capiCluster *clusterv1.Cluster) (string, error) {
 	managerOwnerRef := GetManagementOwnerRef(capiMachine)
 	if managerOwnerRef == nil {
 		return "", errors.Errorf("could not find owner UID for %s/%s", csm.Namespace, csm.Name)
@@ -99,9 +99,9 @@ func GenerateAffinityGroupName(csm infrav1.CloudStackMachine, capiMachine *clust
 	// If the machine's owner is KubeadmControlPlane or EtcdadmCluster, then we don't consider the name and UID of the
 	// owner, since there will only be one of each of those per cluster.
 	if managerOwnerRef.Kind == "KubeadmControlPlane" || managerOwnerRef.Kind == "EtcdadmCluster" {
-		return fmt.Sprintf("%sAffinity-%s-%s",
-			titleCaser.String(csm.Spec.Affinity), managerOwnerRef.Kind, csm.Spec.FailureDomainName), nil
+		return fmt.Sprintf("%s-%s-%sAffinity-%s-%s",
+			capiCluster.Name, capiCluster.UID, titleCaser.String(csm.Spec.Affinity), managerOwnerRef.Kind, csm.Spec.FailureDomainName), nil
 	}
-	return fmt.Sprintf("%sAffinity-%s-%s-%s",
-		titleCaser.String(csm.Spec.Affinity), managerOwnerRef.Name, managerOwnerRef.UID, csm.Spec.FailureDomainName), nil
+	return fmt.Sprintf("%s-%s-%sAffinity-%s-%s-%s",
+		capiCluster.Name, capiCluster.UID, titleCaser.String(csm.Spec.Affinity), managerOwnerRef.Name, managerOwnerRef.UID, csm.Spec.FailureDomainName), nil
 }

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -128,10 +128,10 @@ func fetchOwnerRef(refList []meta.OwnerReference, kind string) *meta.OwnerRefere
 func GetManagementOwnerRef(capiMachine *clusterv1.Machine) *meta.OwnerReference {
 	if util.IsControlPlaneMachine(capiMachine) {
 		return fetchOwnerRef(capiMachine.OwnerReferences, "KubeadmControlPlane")
-	} else if ref := fetchOwnerRef(capiMachine.OwnerReferences, "MachineSet"); ref != nil {
+	} else if ref := fetchOwnerRef(capiMachine.OwnerReferences, "EtcdadmCluster"); ref != nil {
 		return ref
 	}
-	return fetchOwnerRef(capiMachine.OwnerReferences, "EtcdadmCluster")
+	return fetchOwnerRef(capiMachine.OwnerReferences, "MachineSet")
 }
 
 // GetOwnerOfKind returns the Cluster object owning the current resource of passed kind.


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/issues/240
Closes https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/issues/239
*Description of changes:*
* Separate naming scheme for `KubeadmControlPlane` & `EtcdadmCluster`.
`<cluster name>-<cluster uid>-<affinity type>Affinity-<owner kind>-<failure domain name>`
* Prefix generate affinity group name with `<cluster name>-<cluster uid>-`.
* Use `AffinityGroupRef` to store information about the attached affinity group and use it prevent generation of a new affinity group in case the owner ref changes.


*Testing performed:*
* Tested locally with a CloudStack setup.
* Ran E2E tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->