### PR TITLE
hack/cleanup-ag: spurious affinity group cleaner

### DIFF
--- a/hack/cleanup-ag.sh
+++ b/hack/cleanup-ag.sh
@@ -141,7 +141,7 @@ then
     exit 1
 fi
 
-if ! command -v cmkd &> /dev/null
+if ! command -v cmk &> /dev/null
 then
     echo "[error] cmk could not be found, please install https://github.com/apache/cloudstack-cloudmonkey/releases/tag/6.4.0-rc1 or newer"
     exit 1

--- a/hack/cleanup-ag.sh
+++ b/hack/cleanup-ag.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requires: jq, kubectl, cmk (get https://github.com/apache/cloudstack-cloudmonkey/releases/tag/6.4.0-rc1 or later)
+#
+# About: this tool helps to remove CloudStack affinity groups from CAPC
+# management cluster which are not assigned to any instances.
+#
+# Usage and help:
+# chmod +x cleanup-ag.sh
+# ./cleanup-ag.sh -h
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export DRY_RUN=false
+export VERBOSE=false
+export KUBECONFIG=$HOME/.kube/config
+
+debug() {
+  if [[ "$VERBOSE" == "true" ]]; then
+    echo $@
+  fi
+}
+
+get_affinity_groups() {
+  kubectl get cloudstackaffinitygroups -o json -A | jq -r '.items[].metadata.name'
+}
+
+get_cluster() {
+  affinityGroup=$1
+  kubectl get cloudstackaffinitygroup $affinityGroup -o json | jq -r '.metadata.labels."cluster.x-k8s.io/cluster-name"'
+}
+
+get_cluster_credentials() {
+  cluster=$1
+  kubectl get cloudstackcluster $cluster -o json | jq -r '.spec.failureDomains[].acsEndpoint.name' | uniq
+}
+
+setup_acs_credentials() {
+  credential=$1
+  export CS_URL=$(kubectl get secret $credential -o json | jq -r '.data."api-url"' | base64 -D)
+  export CS_APIKEY=$(kubectl get secret $credential -o json | jq -r '.data."api-key"' | base64 -D)
+  export CS_SECRETKEY=$(kubectl get secret $credential -o json | jq -r '.data."secret-key"' | base64 -D)
+  debug "Using CloudStack Control Plane URL: $CS_URL and CloudStack Account: $(run_cmk list users | jq -r '.user[] | .account + " and User: " + .username')"
+}
+
+run_cmk() {
+  cmk -u $CS_URL -k $CS_APIKEY -s $CS_SECRETKEY -o json $@
+}
+
+main() {
+  for ag in $(get_affinity_groups); do
+    echo "Checking CloudStack Affinity Group: $ag"
+    cluster=$(get_cluster $ag)
+    for credential in $(get_cluster_credentials $cluster); do
+      setup_acs_credentials $credential
+      CS_AG_ID=$(kubectl get cloudstackaffinitygroup $ag -o json | jq -r '.spec.id')
+      CS_AG_VMS=$(run_cmk list affinitygroups id=$CS_AG_ID | jq -r '.affinitygroup[0].virtualmachineIds')
+      if [[ "$CS_AG_VMS" == "null" ]]; then
+        echo "Found Affinity Group ($CS_AG_ID) with no instances assigned:" $ag
+        if [[ "$DRY_RUN" == "false" ]]; then
+          kubectl delete cloudstackaffinitygroup $ag
+          echo "Affinity Group ($CS_AG_ID) $ag has been removed"
+        else
+          echo "[DRY RUN] Affinity Group ($CS_AG_ID) $ag has been removed"
+        fi
+      fi
+    done
+  done
+}
+
+help() {
+  echo "Usage: $0 [-d|k|h|v]"
+  echo
+  echo "This cleanup tool helps to remove CloudStack affinity groups from CAPC"
+  echo "management cluster which are not assigned to any instances, which may"
+  echo "have been created as a side effect of other operations. This tool checks"
+  echo "all the cloudstackaffinitygroups using its CloudStack cluster specific"
+  echo "credential(s) and uses cmk to check if the affinity group have no"
+  echo "instances assigned. In dry-run, it outputs such affinity groups"
+  echo "otherwise it deletes them."
+  echo
+  echo "Options:"
+  echo "-d     Runs the tools in dry-run mode"
+  echo "-k     Pass custom kube config, default: \$HOME/.kube/config"
+  echo "-h     Print this help"
+  echo "-v     Verbose mode"
+  echo
+}
+
+while getopts ":dkvh" option; do
+   case $option in
+      d)
+         export DRY_RUN=true;;
+      k)
+         export KUBECONFIG=$OPTARG;;
+      v)
+         export VERBOSE=true;;
+      h)
+         help
+         exit;;
+     \?)
+         echo "Error: Invalid option provided, please see help docs"
+         help
+         exit;;
+   esac
+done
+
+main

--- a/hack/cleanup-ag.sh
+++ b/hack/cleanup-ag.sh
@@ -70,7 +70,7 @@ setup_acs_credentials() {
 
 main() {
   for ag in $(get_affinity_groups); do
-    echo "Checking CloudStack Affinity Group: $ag"
+    echo "[info] Checking CloudStack Affinity Group: $ag"
     cluster=$(get_cluster $ag)
     for credential in $(get_cluster_credentials $cluster); do
       setup_acs_credentials $credential
@@ -79,7 +79,7 @@ main() {
       if [[ "$CS_AG_VMS" == "null" ]]; then
         echo "[info] Found Affinity Group ($CS_AG_ID) with no instances assigned:" $ag
         if [[ "$DRY_RUN" == "false" ]]; then
-          _kubectl delete cloudstackaffinitygroup $ag
+          kubectl -n $NAMESPACE delete cloudstackaffinitygroup $ag
           echo "[info] Affinity Group ($CS_AG_ID) $ag has been removed"
         else
           echo "[dryrun] Affinity Group ($CS_AG_ID) $ag has been removed"

--- a/hack/cleanup-ag.sh
+++ b/hack/cleanup-ag.sh
@@ -77,7 +77,7 @@ main() {
       CS_AG_ID=$(_kubectl get cloudstackaffinitygroup $ag | jq -r '.spec.id')
       CS_AG_VMS=$(_cmk list affinitygroups id=$CS_AG_ID | jq -r '.affinitygroup[0].virtualmachineIds')
       if [[ "$CS_AG_VMS" == "null" ]]; then
-        echo "Found Affinity Group ($CS_AG_ID) with no instances assigned:" $ag
+        echo "[info] Found Affinity Group ($CS_AG_ID) with no instances assigned:" $ag
         if [[ "$DRY_RUN" == "false" ]]; then
           _kubectl delete cloudstackaffinitygroup $ag
           echo "[info] Affinity Group ($CS_AG_ID) $ag has been removed"


### PR DESCRIPTION
*Issue #, if available:*

Related to https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/issues/240

*Description of changes:*
This cleanup tool helps to remove CloudStack affinity groups from CAPC management cluster which are not assigned to any instances, which may have been created as a side effect of other operations. This tool checks all the cloudstackaffinitygroups using its CloudStack cluster specific credential(s) and uses cmk to check if the affinity group have no instances assigned. In dry-run, it outputs such affinity groups otherwise it deletes them.

*Testing performed:*

- Created a CAPC cluster with affinity groups specified as `anti` or `pro`
```
spec:
  template:
    spec:
      affinity: anti
      offering:
        name: Large
      template:
        name: rockylinux-8-kube-v1.27.2-kvm
```
- Delete the machine deployment to simulate upgrade or similar operations
```
kubectl delete  machinedeployment capc-cluster-md-0
```
- Re-applied the capc-cluster yaml, to see new machines being deployed and new affinity groups created
- However, older affinity groups aren't cleaned up
- Install dependencies for this tool such as cmk and jq (note: cmk should be latest from main branch or get this pre-rc build: https://github.com/apache/cloudstack-cloudmonkey/releases/tag/6.4.0-rc1)
- Run this tool in dry-run mode:
```
./cleanup-ag.sh -d
Checking CloudStack Affinity Group: antiaffinity-capc-cluster-control-plane-746e19e9-ea06-4ca3-b9b1-ebeb4753e6c7-failure-domain-1
Checking CloudStack Affinity Group: antiaffinity-capc-cluster-md-0-7f8d8bf7c8x946qk-c7a7a6d9-7d3d-480d-8d46-ff8260b8cd7f-failure-domain-1
Checking CloudStack Affinity Group: antiaffinity-capc-cluster-md-0-7f8d8bf7c8xfph69-915f82e5-e346-4324-8dd6-b793ea6768e5-failure-domain-1
Found Affinity Group (4db6e60d-942d-48b9-9e8d-f27a911ceaf4) with no instances assigned: antiaffinity-capc-cluster-md-0-7f8d8bf7c8xfph69-915f82e5-e346-4324-8dd6-b793ea6768e5-failure-domain-1
[DRY RUN] Affinity Group (4db6e60d-942d-48b9-9e8d-f27a911ceaf4) antiaffinity-capc-cluster-md-0-7f8d8bf7c8xfph69-915f82e5-e346-4324-8dd6-b793ea6768e5-failure-domain-1 has been removed
Checking CloudStack Affinity Group: proaffinity-capc-cluster2-control-plane-f3cab1ca-32a0-4a41-ad2f-a681bd5a60c8-failure-domain-1
Checking CloudStack Affinity Group: proaffinity-capc-cluster2-md-0-74f9cbf9dx445dq-df4594c2-9b98-44ab-8901-acfadf68445e-failure-domain-1
Found Affinity Group (a7ea7e9f-b7c8-4607-bc15-3ebe9bc95594) with no instances assigned: proaffinity-capc-cluster2-md-0-74f9cbf9dx445dq-df4594c2-9b98-44ab-8901-acfadf68445e-failure-domain-1
[DRY RUN] Affinity Group (a7ea7e9f-b7c8-4607-bc15-3ebe9bc95594) proaffinity-capc-cluster2-md-0-74f9cbf9dx445dq-df4594c2-9b98-44ab-8901-acfadf68445e-failure-domain-1 has been removed
Checking CloudStack Affinity Group: proaffinity-capc-cluster2-md-0-74f9cbf9dxdqk85-160cd89f-4361-4db4-aaf0-e93c28a0dae0-failure-domain-1
Checking CloudStack Affinity Group: proaffinity-capc-cluster2-md-0-74f9cbf9dxlxx6c-bf59c3c6-bc8d-44e6-917f-ececf69e75bb-failure-domain-1
Found Affinity Group (c800d58c-31a8-493c-b45e-94a8e9f5a149) with no instances assigned: proaffinity-capc-cluster2-md-0-74f9cbf9dxlxx6c-bf59c3c6-bc8d-44e6-917f-ececf69e75bb-failure-domain-1
[DRY RUN] Affinity Group (c800d58c-31a8-493c-b45e-94a8e9f5a149) proaffinity-capc-cluster2-md-0-74f9cbf9dxlxx6c-bf59c3c6-bc8d-44e6-917f-ececf69e75bb-failure-domain-1 has been removed
```
- Next, run the tool to cleanup:
```
> ./cleanup-ag.sh
Checking CloudStack Affinity Group: antiaffinity-capc-cluster-control-plane-746e19e9-ea06-4ca3-b9b1-ebeb4753e6c7-failure-domain-1
Checking CloudStack Affinity Group: antiaffinity-capc-cluster-md-0-7f8d8bf7c8x946qk-c7a7a6d9-7d3d-480d-8d46-ff8260b8cd7f-failure-domain-1
Checking CloudStack Affinity Group: antiaffinity-capc-cluster-md-0-7f8d8bf7c8xfph69-915f82e5-e346-4324-8dd6-b793ea6768e5-failure-domain-1
Found Affinity Group (4db6e60d-942d-48b9-9e8d-f27a911ceaf4) with no instances assigned: antiaffinity-capc-cluster-md-0-7f8d8bf7c8xfph69-915f82e5-e346-4324-8dd6-b793ea6768e5-failure-domain-1
cloudstackaffinitygroup.infrastructure.cluster.x-k8s.io "antiaffinity-capc-cluster-md-0-7f8d8bf7c8xfph69-915f82e5-e346-4324-8dd6-b793ea6768e5-failure-domain-1" deleted
Affinity Group (4db6e60d-942d-48b9-9e8d-f27a911ceaf4) antiaffinity-capc-cluster-md-0-7f8d8bf7c8xfph69-915f82e5-e346-4324-8dd6-b793ea6768e5-failure-domain-1 has been removed
Checking CloudStack Affinity Group: proaffinity-capc-cluster2-control-plane-f3cab1ca-32a0-4a41-ad2f-a681bd5a60c8-failure-domain-1
Checking CloudStack Affinity Group: proaffinity-capc-cluster2-md-0-74f9cbf9dx445dq-df4594c2-9b98-44ab-8901-acfadf68445e-failure-domain-1
Found Affinity Group (a7ea7e9f-b7c8-4607-bc15-3ebe9bc95594) with no instances assigned: proaffinity-capc-cluster2-md-0-74f9cbf9dx445dq-df4594c2-9b98-44ab-8901-acfadf68445e-failure-domain-1
cloudstackaffinitygroup.infrastructure.cluster.x-k8s.io "proaffinity-capc-cluster2-md-0-74f9cbf9dx445dq-df4594c2-9b98-44ab-8901-acfadf68445e-failure-domain-1" deleted
Affinity Group (a7ea7e9f-b7c8-4607-bc15-3ebe9bc95594) proaffinity-capc-cluster2-md-0-74f9cbf9dx445dq-df4594c2-9b98-44ab-8901-acfadf68445e-failure-domain-1 has been removed
Checking CloudStack Affinity Group: proaffinity-capc-cluster2-md-0-74f9cbf9dxdqk85-160cd89f-4361-4db4-aaf0-e93c28a0dae0-failure-domain-1
Checking CloudStack Affinity Group: proaffinity-capc-cluster2-md-0-74f9cbf9dxlxx6c-bf59c3c6-bc8d-44e6-917f-ececf69e75bb-failure-domain-1
Found Affinity Group (c800d58c-31a8-493c-b45e-94a8e9f5a149) with no instances assigned: proaffinity-capc-cluster2-md-0-74f9cbf9dxlxx6c-bf59c3c6-bc8d-44e6-917f-ececf69e75bb-failure-domain-1
cloudstackaffinitygroup.infrastructure.cluster.x-k8s.io "proaffinity-capc-cluster2-md-0-74f9cbf9dxlxx6c-bf59c3c6-bc8d-44e6-917f-ececf69e75bb-failure-domain-1" deleted
Affinity Group (c800d58c-31a8-493c-b45e-94a8e9f5a149) proaffinity-capc-cluster2-md-0-74f9cbf9dxlxx6c-bf59c3c6-bc8d-44e6-917f-ececf69e75bb-failure-domain-1 has been removed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->