### PR TITLE
Feature: Support externally managed cluster infrastructure

### DIFF
--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -126,7 +127,7 @@ func (r *CloudStackMachineReconciliationRunner) Reconcile() (retRes ctrl.Result,
 		r.ConsiderAffinity,
 		r.GetOrCreateVMInstance,
 		r.RequeueIfInstanceNotRunning,
-		r.AddToLBIfNeeded,
+		r.RunIf(func() bool { return !annotations.IsExternallyManaged(r.CSCluster) }, r.AddToLBIfNeeded),
 		r.GetOrCreateMachineStateChecker,
 	)
 }


### PR DESCRIPTION
Adds support for the ResourceExternallyManaged predicate

*Issue #, if available:*

*Description of changes:*

This PR implements [this CAEP](https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/proposals/20210203-externally-managed-cluster-infrastructure.md) allowing for cluster infrastructure to be externally managed. This allows f.e. to use an external (possibly already existing) control plane, while still leveraging CAPI/CAPC for the deployment of workers using MachineDeployments.

`CloudStackCluster`s marked with `cluster.x-k8s.io/managed-by` annotation should be skipped from reconciliation.

Related links:

[📖 CAEP: Add support for infrastructure cluster resources to be managed externally](https://github.com/kubernetes-sigs/cluster-api/pull/4135)
[✨ Add externally managed annotation and predicate](https://github.com/kubernetes-sigs/cluster-api/pull/4303)

*Testing performed:*

make test-sanity
make test
tested with kind based dev mgmt cluster

With the following CloudStackCluster excerpt:

```yaml
apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
kind: CloudStackCluster
metadata:
  name: hrak-test-cluster
  namespace: default
  annotations:
    cluster.x-k8s.io/managed-by: "external"
```

Observe CAPC waiting for ready status on CloudStackCluster, MachineDeployment waiting for ready status on CloudStackCluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->