### PR TITLE
Propagate error from erroneous VM deployment

### DIFF
--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -337,16 +337,17 @@ func (c *client) DeployVM(
 		}
 
 		// We didn't find a VM so return the original error.
-		if vm == nil {
-			return err
+		if vm != nil {
+			csMachine.Spec.InstanceID = pointer.String(vm.Id)
+			csMachine.Status.InstanceState = vm.State
 		}
 
-		csMachine.Spec.InstanceID = pointer.String(vm.Id)
-		csMachine.Status.InstanceState = vm.State
-	} else {
-		csMachine.Spec.InstanceID = pointer.String(deployVMResp.Id)
-		csMachine.Status.Status = pointer.String(metav1.StatusSuccess)
+		return err
 	}
+
+	csMachine.Spec.InstanceID = pointer.String(deployVMResp.Id)
+	csMachine.Status.Status = pointer.String(metav1.StatusSuccess)
+
 	return nil
 }
 


### PR DESCRIPTION
When creating virtual machines the CloudStack API call may fail but a VM is still created. In this case, we populate VM data on the CloudStackMachine object so the end user can manually clean up. However, we don't return the underlying error that results in the error being swallowed. 