### PR TITLE
Stop swallowing VM deployment error

### DIFF
--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -343,10 +343,13 @@ func (c *client) DeployVM(
 
 		csMachine.Spec.InstanceID = pointer.String(vm.Id)
 		csMachine.Status.InstanceState = vm.State
-	} else {
-		csMachine.Spec.InstanceID = pointer.String(deployVMResp.Id)
-		csMachine.Status.Status = pointer.String(metav1.StatusSuccess)
+
+		return fmt.Errorf("incomplete vm deployment (vm_id=%v): %w", vm.Id, err)
 	}
+
+	csMachine.Spec.InstanceID = pointer.String(deployVMResp.Id)
+	csMachine.Status.Status = pointer.String(metav1.StatusSuccess)
+
 	return nil
 }
 


### PR DESCRIPTION
When a VM fails to deploy we swallow the original error resulting in no controller logs entries and no events being generated. Returning the error ensures both occur and provides operator with an indication of the problem.