### PR TITLE
Use Domain ID instead of path while resolving User

### DIFF
--- a/pkg/cloud/client.go
+++ b/pkg/cloud/client.go
@@ -186,7 +186,7 @@ func NewClientFromConf(conf Config, clientConfig *corev1.ConfigMap) (Client, err
 		Account: Account{
 			Name: userResponse.Users[0].Account,
 			Domain: Domain{
-				Path: userResponse.Users[0].Domain,
+				ID: userResponse.Users[0].Domainid,
 			},
 		},
 	}


### PR DESCRIPTION
*Issue #, if available:* Does not fix but alleviates #321 in few code paths.

*Description of changes:*
The ListUsers API only returns a domain ID and a domain name pertaining to the user provided as input. Using domain name in place of domain path, leads to assuming the parent domain here is `ROOT`. Instead this change, sets the domain id which is more deterministic and leads to clear identification and resolution of domain.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->