### PR TITLE
Remove finalizer if affinity group is already deleted on Cloudstack

### DIFF
--- a/controllers/cloudstackaffinitygroup_controller.go
+++ b/controllers/cloudstackaffinitygroup_controller.go
@@ -76,9 +76,14 @@ func (r *CloudStackAGReconciliationRunner) Reconcile() (ctrl.Result, error) {
 }
 
 func (r *CloudStackAGReconciliationRunner) ReconcileDelete() (ctrl.Result, error) {
-	group := &cloud.AffinityGroup{Name: r.ReconciliationSubject.Name}
+	group := &cloud.AffinityGroup{Name: r.ReconciliationSubject.Spec.Name}
 	_ = r.CSUser.FetchAffinityGroup(group)
-	if group.ID == "" { // Affinity group not found, must have been deleted.
+	// Affinity group not found, must have been deleted.
+	if group.ID == "" {
+		// Deleting affinity groups on Cloudstack can return error but succeed in
+		// deleting the affinity group. Removing finalizer if affinity group is not
+		// present on Cloudstack ensures affinity group object deletion is not blocked.
+		controllerutil.RemoveFinalizer(r.ReconciliationSubject, infrav1.AffinityGroupFinalizer)
 		return ctrl.Result{}, nil
 	}
 	if err := r.CSUser.DeleteAffinityGroup(group); err != nil {


### PR DESCRIPTION
*Issue #, if available:*
#339 

*Description of changes:*
The affinity group controller on delete reconcile loops checks if the affinity group has been already deleted on CloudStack and if yes will remove the finalizer. This prevents deletion of affinity group objects present on the cluster to be stuck due to CloudStack API errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->