### PR TITLE
[release-0.4] Make affinity group and failure domain controller run with multiple workers

### DIFF
--- a/controllers/cloudstackaffinitygroup_controller.go
+++ b/controllers/cloudstackaffinitygroup_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
@@ -89,8 +90,9 @@ func (r *CloudStackAGReconciliationRunner) ReconcileDelete() (ctrl.Result, error
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (reconciler *CloudStackAffinityGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (reconciler *CloudStackAffinityGroupReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
 		For(&infrav1.CloudStackAffinityGroup{}).
 		Complete(reconciler)
 }

--- a/controllers/cloudstackaffinitygroup_controller_test.go
+++ b/controllers/cloudstackaffinitygroup_controller_test.go
@@ -23,13 +23,14 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 var _ = Describe("CloudStackAffinityGroupReconciler", func() {
 	BeforeEach(func() {
 		SetupTestEnvironment() // Must happen before setting up managers/reconcilers.
 		dummies.SetDummyVars()
-		Ω(AffinityGReconciler.SetupWithManager(k8sManager)).Should(Succeed()) // Register CloudStack AffinityGReconciler.
+		Ω(AffinityGReconciler.SetupWithManager(k8sManager, controller.Options{})).Should(Succeed()) // Register CloudStack AffinityGReconciler.
 	})
 
 	It("Should patch back the affinity group as ready after calling GetOrCreateAffinityGroup.", func() {

--- a/controllers/cloudstackcluster_controller_test.go
+++ b/controllers/cloudstackcluster_controller_test.go
@@ -30,9 +30,9 @@ import (
 var _ = Describe("CloudStackClusterReconciler", func() {
 	Context("With k8s like test environment.", func() {
 		BeforeEach(func() {
-			SetupTestEnvironment()                                                                         // Must happen before setting up managers/reconcilers.
-			Ω(ClusterReconciler.SetupWithManager(ctx, k8sManager, controller.Options{})).Should(Succeed()) // Register CloudStack ClusterReconciler.
-			Ω(FailureDomainReconciler.SetupWithManager(k8sManager)).Should(Succeed())                      // Register CloudStack FailureDomainReconciler.
+			SetupTestEnvironment()                                                                          // Must happen before setting up managers/reconcilers.
+			Ω(ClusterReconciler.SetupWithManager(ctx, k8sManager, controller.Options{})).Should(Succeed())  // Register CloudStack ClusterReconciler.
+			Ω(FailureDomainReconciler.SetupWithManager(k8sManager, controller.Options{})).Should(Succeed()) // Register CloudStack FailureDomainReconciler.
 		})
 
 		It("Should create a CloudStackFailureDomain.", func() {

--- a/controllers/cloudstackfailuredomain_controller.go
+++ b/controllers/cloudstackfailuredomain_controller.go
@@ -24,6 +24,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sort"
 
@@ -263,7 +264,9 @@ func (r *CloudStackFailureDomainReconciliationRunner) RemoveFinalizer() (ctrl.Re
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (reconciler *CloudStackFailureDomainReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	_, err := ctrl.NewControllerManagedBy(mgr).For(&infrav1.CloudStackFailureDomain{}).Build(reconciler)
-	return err
+func (reconciler *CloudStackFailureDomainReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(opts).
+		For(&infrav1.CloudStackFailureDomain{}).
+		Complete(reconciler)
 }

--- a/controllers/cloudstackfailuredomain_controller_test.go
+++ b/controllers/cloudstackfailuredomain_controller_test.go
@@ -28,14 +28,15 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 var _ = Describe("CloudStackFailureDomainReconciler", func() {
 	Context("With k8s like test environment.", func() {
 		BeforeEach(func() {
 			dummies.SetDummyVars()
-			SetupTestEnvironment()                                                    // Must happen before setting up managers/reconcilers.
-			Ω(FailureDomainReconciler.SetupWithManager(k8sManager)).Should(Succeed()) // Register CloudStack FailureDomainReconciler.
+			SetupTestEnvironment()                                                                          // Must happen before setting up managers/reconcilers.
+			Ω(FailureDomainReconciler.SetupWithManager(k8sManager, controller.Options{})).Should(Succeed()) // Register CloudStack FailureDomainReconciler.
 			// Modify failure domain name the same way the cluster controller would.
 			dummies.CSFailureDomain1.Name = dummies.CSFailureDomain1.Name + "-" + dummies.CSCluster.Name
 

--- a/main.go
+++ b/main.go
@@ -75,8 +75,10 @@ type managerOpts struct {
 	WatchFilterValue     string
 	CertDir              string
 
-	CloudStackClusterConcurrency int
-	CloudStackMachineConcurrency int
+	CloudStackClusterConcurrency       int
+	CloudStackMachineConcurrency       int
+	CloudStackAffinityGroupConcurrency int
+	CloudStackFailureDomainConcurrency int
 }
 
 func setFlags() *managerOpts {
@@ -132,6 +134,18 @@ func setFlags() *managerOpts {
 		"cloudstackmachine-concurrency",
 		10,
 		"Maximum concurrent reconciles for CloudStackMachine resources",
+	)
+	flag.IntVar(
+		&opts.CloudStackAffinityGroupConcurrency,
+		"cloudstackaffinitygroup-concurrency",
+		1,
+		"Maximum concurrent reconciles for CloudStackAffinityGroup resources",
+	)
+	flag.IntVar(
+		&opts.CloudStackFailureDomainConcurrency,
+		"cloudstackfailuredomain-concurrency",
+		1,
+		"Maximum concurrent reconciles for CloudStackFailureDomain resources",
 	)
 
 	return opts
@@ -222,11 +236,11 @@ func setupReconcilers(ctx context.Context, base utils.ReconcilerBase, opts manag
 		setupLog.Error(err, "unable to create controller", "controller", "CloudStackIsoNetReconciler")
 		os.Exit(1)
 	}
-	if err := (&controllers.CloudStackAffinityGroupReconciler{ReconcilerBase: base}).SetupWithManager(mgr); err != nil {
+	if err := (&controllers.CloudStackAffinityGroupReconciler{ReconcilerBase: base}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: opts.CloudStackAffinityGroupConcurrency}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CloudStackAffinityGroup")
 		os.Exit(1)
 	}
-	if err := (&controllers.CloudStackFailureDomainReconciler{ReconcilerBase: base}).SetupWithManager(mgr); err != nil {
+	if err := (&controllers.CloudStackFailureDomainReconciler{ReconcilerBase: base}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: opts.CloudStackFailureDomainConcurrency}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CloudStackFailureDomain")
 		os.Exit(1)
 	}


### PR DESCRIPTION
*Description of changes:*
Affinity group and Failure domain controllers are setup with a single worker. This change introduces concurrent workers for both of these controllers. Users can tweak the number of workers using a flag in their deployments. Workers default to 1 for both controllers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->