### PR TITLE
Support re-assignment of another failure domain when the machine failed to provision

### DIFF
--- a/api/v1beta3/cloudstackmachine_types.go
+++ b/api/v1beta3/cloudstackmachine_types.go
@@ -27,6 +27,7 @@ import (
 const MachineFinalizer = "cloudstackmachine.infrastructure.cluster.x-k8s.io"
 
 const MachineCreateFailedAnnotation = "cluster.x-k8s.io/vm-create-failed"
+const CloudStackJobIDAnnotation = "cluster.x-k8s.io/cs-job-id"
 
 const (
 	ProAffinity  = "pro"
@@ -95,6 +96,25 @@ type CloudStackMachineSpec struct {
 
 func (c *CloudStackMachine) CompressUserdata() bool {
 	return c.Spec.UncompressedUserData == nil || !*c.Spec.UncompressedUserData
+}
+
+func (c *CloudStackMachine) SetJobID(id string) {
+	if c.Annotations == nil {
+		c.Annotations = map[string]string{}
+	}
+	c.Annotations[CloudStackJobIDAnnotation] = id
+}
+
+func (c *CloudStackMachine) GetJobID() string {
+	if c.Annotations == nil {
+		return ""
+	}
+
+	return c.Annotations[CloudStackJobIDAnnotation]
+}
+
+func (c *CloudStackMachine) ClearJobID() {
+	delete(c.Annotations, CloudStackJobIDAnnotation)
 }
 
 func (c *CloudStackMachine) MarkAsFailed() {

--- a/api/v1beta3/cloudstackmachine_types.go
+++ b/api/v1beta3/cloudstackmachine_types.go
@@ -26,6 +26,8 @@ import (
 // The presence of a finalizer prevents CAPI from deleting the corresponding CAPI data.
 const MachineFinalizer = "cloudstackmachine.infrastructure.cluster.x-k8s.io"
 
+const MachineCreateFailAnnotation = "cluster.x-k8s.io/vm-create-failed"
+
 const (
 	ProAffinity  = "pro"
 	AntiAffinity = "anti"
@@ -93,6 +95,21 @@ type CloudStackMachineSpec struct {
 
 func (c *CloudStackMachine) CompressUserdata() bool {
 	return c.Spec.UncompressedUserData == nil || !*c.Spec.UncompressedUserData
+}
+
+func (c *CloudStackMachine) MarkAsFailed() {
+	if c.Annotations == nil {
+		c.Annotations = map[string]string{}
+	}
+	c.Annotations[MachineCreateFailAnnotation] = "true"
+}
+
+func (c *CloudStackMachine) ClearFailed() {
+	delete(c.Annotations, MachineCreateFailAnnotation)
+}
+
+func (c *CloudStackMachine) HasFailed() bool {
+	return c.Annotations != nil && c.Annotations[MachineCreateFailAnnotation] == "true"
 }
 
 type CloudStackResourceIdentifier struct {

--- a/api/v1beta3/cloudstackmachine_types.go
+++ b/api/v1beta3/cloudstackmachine_types.go
@@ -26,7 +26,7 @@ import (
 // The presence of a finalizer prevents CAPI from deleting the corresponding CAPI data.
 const MachineFinalizer = "cloudstackmachine.infrastructure.cluster.x-k8s.io"
 
-const MachineCreateFailAnnotation = "cluster.x-k8s.io/vm-create-failed"
+const MachineCreateFailedAnnotation = "cluster.x-k8s.io/vm-create-failed"
 
 const (
 	ProAffinity  = "pro"
@@ -101,15 +101,15 @@ func (c *CloudStackMachine) MarkAsFailed() {
 	if c.Annotations == nil {
 		c.Annotations = map[string]string{}
 	}
-	c.Annotations[MachineCreateFailAnnotation] = "true"
+	c.Annotations[MachineCreateFailedAnnotation] = "true"
 }
 
 func (c *CloudStackMachine) ClearFailed() {
-	delete(c.Annotations, MachineCreateFailAnnotation)
+	delete(c.Annotations, MachineCreateFailedAnnotation)
 }
 
 func (c *CloudStackMachine) HasFailed() bool {
-	return c.Annotations != nil && c.Annotations[MachineCreateFailAnnotation] == "true"
+	return c.Annotations != nil && c.Annotations[MachineCreateFailedAnnotation] == "true"
 }
 
 type CloudStackResourceIdentifier struct {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,6 +58,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - cluster.x-k8s.io

--- a/controllers/cloudstackaffinitygroup_controller.go
+++ b/controllers/cloudstackaffinitygroup_controller.go
@@ -61,7 +61,7 @@ func (reconciler *CloudStackAffinityGroupReconciler) Reconcile(ctx context.Conte
 	r.UsingBaseReconciler(reconciler.ReconcilerBase).ForRequest(req).WithRequestCtx(ctx)
 	r.WithAdditionalCommonStages(
 		r.GetFailureDomainByName(func() string { return r.ReconciliationSubject.Spec.FailureDomainName }, r.FailureDomain),
-		r.AsFailureDomainUser(&r.FailureDomain.Spec))
+		r.AsFailureDomainUser(ctx, &r.FailureDomain.Spec))
 	return r.RunBaseReconciliationStages()
 }
 

--- a/controllers/cloudstackfailuredomain_controller.go
+++ b/controllers/cloudstackfailuredomain_controller.go
@@ -84,7 +84,7 @@ func (reconciler *CloudStackFailureDomainReconciler) Reconcile(ctx context.Conte
 
 // Reconcile on the ReconciliationRunner actually attempts to modify or create the reconciliation subject.
 func (r *CloudStackFailureDomainReconciliationRunner) Reconcile() (retRes ctrl.Result, retErr error) {
-	res, err := r.AsFailureDomainUser(&r.ReconciliationSubject.Spec)()
+	res, err := r.AsFailureDomainUser(r.RequestCtx, &r.ReconciliationSubject.Spec)()
 	if r.ShouldReturn(res, err) {
 		return res, err
 	}

--- a/controllers/cloudstackfailuredomain_controller.go
+++ b/controllers/cloudstackfailuredomain_controller.go
@@ -18,6 +18,8 @@ package controllers
 
 import (
 	"context"
+	"sort"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -26,7 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sort"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	csCtrlrUtils "sigs.k8s.io/cluster-api-provider-cloudstack/controllers/utils"

--- a/controllers/cloudstackisolatednetwork_controller.go
+++ b/controllers/cloudstackisolatednetwork_controller.go
@@ -61,7 +61,7 @@ func (reconciler *CloudStackIsoNetReconciler) Reconcile(ctx context.Context, req
 	r.UsingBaseReconciler(reconciler.ReconcilerBase).ForRequest(req).WithRequestCtx(ctx)
 	r.WithAdditionalCommonStages(
 		r.GetFailureDomainByName(func() string { return r.ReconciliationSubject.Spec.FailureDomainName }, r.FailureDomain),
-		r.AsFailureDomainUser(&r.FailureDomain.Spec),
+		r.AsFailureDomainUser(r.RequestCtx, &r.FailureDomain.Spec),
 	)
 	return r.RunBaseReconciliationStages()
 }

--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
+
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/controllers/utils"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"

--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -28,12 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
-
-	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
-	"sigs.k8s.io/cluster-api-provider-cloudstack/controllers/utils"
-	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
-	cserrors "sigs.k8s.io/cluster-api-provider-cloudstack/pkg/errors"
-	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/failuredomains"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/predicates"
@@ -45,6 +39,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
+	"sigs.k8s.io/cluster-api-provider-cloudstack/controllers/utils"
+	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
+	cserrors "sigs.k8s.io/cluster-api-provider-cloudstack/pkg/errors"
+	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/failuredomains"
 )
 
 var (

--- a/controllers/cloudstackmachine_controller_test.go
+++ b/controllers/cloudstackmachine_controller_test.go
@@ -250,7 +250,7 @@ var _ = Describe("CloudStackMachineReconciler", func() {
 			setClusterReady(fakeCtrlClient)
 
 			requestNamespacedName := types.NamespacedName{Namespace: dummies.ClusterNameSpace, Name: dummies.CSMachine1.Name}
-			MachineReconciler.AsFailureDomainUser(&dummies.CSFailureDomain1.Spec)
+			MachineReconciler.AsFailureDomainUser(ctx, &dummies.CSFailureDomain1.Spec)
 			res, err := MachineReconciler.Reconcile(ctx, ctrl.Request{NamespacedName: requestNamespacedName})
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(res.RequeueAfter).Should(BeZero())

--- a/controllers/cloudstackmachine_controller_test.go
+++ b/controllers/cloudstackmachine_controller_test.go
@@ -27,14 +27,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
-	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
-	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
+	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
 )
 
 var _ = Describe("CloudStackMachineReconciler", func() {

--- a/controllers/cloudstackmachinestatechecker_controller.go
+++ b/controllers/cloudstackmachinestatechecker_controller.go
@@ -75,7 +75,7 @@ func (r *CloudStackMachineStateCheckerReconciliationRunner) Reconcile() (ctrl.Re
 		r.GetParent(r.CSMachine, r.CAPIMachine),
 		r.CheckPresent(map[string]client.Object{"CloudStackMachine": r.CSMachine, "Machine": r.CAPIMachine}),
 		r.GetFailureDomainByName(func() string { return r.CSMachine.Spec.FailureDomainName }, r.FailureDomain),
-		r.AsFailureDomainUser(&r.FailureDomain.Spec),
+		r.AsFailureDomainUser(r.RequestCtx, &r.FailureDomain.Spec),
 		func() (ctrl.Result, error) {
 			if err := r.CSClient.ResolveVMInstanceDetails(r.CSMachine); err != nil {
 				if !strings.Contains(strings.ToLower(err.Error()), "no match found") {

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -21,19 +21,13 @@ import (
 	"flag"
 	"fmt"
 	"go/build"
-	"k8s.io/client-go/tools/record"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"sigs.k8s.io/cluster-api-provider-cloudstack/test/fakes"
 	"strings"
 	"testing"
 	"time"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/go-logr/logr"
@@ -41,8 +35,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -53,10 +53,8 @@ import (
 	csReconcilers "sigs.k8s.io/cluster-api-provider-cloudstack/controllers"
 	csCtrlrUtils "sigs.k8s.io/cluster-api-provider-cloudstack/controllers/utils"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/mocks"
-
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api-provider-cloudstack/test/fakes"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -165,7 +165,7 @@ type MockCtrlrCloudClientImplementation struct {
 // AsFailureDomainUser is a method used in the reconciliation runner to set up the CloudStack client. Using this here
 // just sets the CSClient to a mock client.
 func (m *MockCtrlrCloudClientImplementation) AsFailureDomainUser(
-	*infrav1.CloudStackFailureDomainSpec) csCtrlrUtils.CloudStackReconcilerMethod {
+	context.Context, *infrav1.CloudStackFailureDomainSpec) csCtrlrUtils.CloudStackReconcilerMethod {
 	return func() (ctrl.Result, error) {
 		m.CSUser = mockCloudClient
 

--- a/controllers/utils/failuredomains.go
+++ b/controllers/utils/failuredomains.go
@@ -22,13 +22,14 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
-	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
-	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/failuredomains"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
+	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
+	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/failuredomains"
 )
 
 // CreateFailureDomain creates a specified CloudStackFailureDomain CRD owned by the ReconcilationSubject.

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -28,9 +28,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	cserrors "sigs.k8s.io/cluster-api-provider-cloudstack/pkg/errors"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 type VMIface interface {

--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -30,8 +30,6 @@ import (
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	cserrors "sigs.k8s.io/cluster-api-provider-cloudstack/pkg/errors"
 )

--- a/pkg/cloud/network.go
+++ b/pkg/cloud/network.go
@@ -22,6 +22,7 @@ import (
 	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 )
 

--- a/pkg/errors/cloudstack.go
+++ b/pkg/errors/cloudstack.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// ACS standard error messages of the form "CloudStack API error 431 (CSExceptionErrorCode: 9999):..."
+	//  This regexp is used to extract CSExceptionCodes from the message.
+	csErrorCodeRegexp, _ = regexp.Compile(".+CSExceptionErrorCode: ([0-9]+).+")
+
+	// List of error codes: https://docs.cloudstack.apache.org/en/latest/developersguide/dev.html#error-handling
+	csTerminalErrorCodes = strings.Split(getEnv("CLOUDSTACK_TERMINAL_FAILURE_CODES", "4250,9999"), ",")
+)
+
+func getEnv(key string, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}
+
+type DeployVMError struct {
+	acsError error
+}
+
+func IsTerminalDeployVMError(err error) bool {
+	deployError := &DeployVMError{}
+	return errors.As(err, &deployError) && deployError.IsTerminal()
+}
+
+func NewDeployVMError(acsError error) error {
+	return &DeployVMError{acsError: acsError}
+}
+
+func (e *DeployVMError) Error() string {
+	if e.acsError == nil {
+		return ""
+	}
+	return e.acsError.Error()
+}
+
+func (e *DeployVMError) IsTerminal() bool {
+	errorCode := GetACSErrorCode(e.acsError)
+	for _, te := range csTerminalErrorCodes {
+		if errorCode == te {
+			return true
+		}
+	}
+	return false
+}
+
+func GetACSErrorCode(acsError error) string {
+	if acsError == nil {
+		return ""
+	}
+
+	matches := csErrorCodeRegexp.FindStringSubmatch(acsError.Error())
+	if len(matches) > 1 {
+		return matches[1]
+	}
+
+	return "No error code"
+}

--- a/pkg/errors/cloudstack_test.go
+++ b/pkg/errors/cloudstack_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DeployVM Error", func() {
+
+	Context("a deploy VM error", func() {
+		It("determine an error is terminal", func() {
+			vmError := DeployVMError{fmt.Errorf(`CloudStack API error 530 (CSExceptionErrorCode: 4250): Internal error executing command, please contact your system administrator`)}
+
+			Expect(vmError.IsTerminal()).Should(BeTrue())
+		})
+
+		It("determine an error is NOT terminal", func() {
+			vmError := DeployVMError{fmt.Errorf(`CloudStack API error 400 (CSExceptionErrorCode: 0): Internal error executing command, please contact your system administrator`)}
+
+			Expect(vmError.IsTerminal()).Should(BeFalse())
+		})
+	})
+
+	Context("a deploy VM error helper", func() {
+		It("determine an error is terminal", func() {
+			vmError := &DeployVMError{fmt.Errorf(`CloudStack API error 530 (CSExceptionErrorCode: 4250): Internal error executing command, please contact your system administrator`)}
+
+			Expect(IsTerminalDeployVMError(vmError)).Should(BeTrue())
+		})
+
+		It("determine an error is terminal when wrapped", func() {
+			vmError := &DeployVMError{fmt.Errorf(`CloudStack API error 530 (CSExceptionErrorCode: 4250): Internal error executing command, please contact your system administrator`)}
+
+			Expect(IsTerminalDeployVMError(fmt.Errorf("a wrapped err: %w", vmError))).Should(BeTrue())
+		})
+
+		It("determine an error is NOT terminal", func() {
+			vmError := &DeployVMError{fmt.Errorf(`CloudStack API error 400 (CSExceptionErrorCode: 0): Internal error executing command, please contact your system administrator`)}
+
+			Expect(IsTerminalDeployVMError(vmError)).Should(BeFalse())
+		})
+	})
+
+})

--- a/pkg/errors/errors_suite_test.go
+++ b/pkg/errors/errors_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestErrors(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Errors Suite")
+}

--- a/pkg/failuredomains/balancer.go
+++ b/pkg/failuredomains/balancer.go
@@ -23,11 +23,12 @@ import (
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"k8s.io/utils/pointer"
-	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
-	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
+	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 )
 
 type Balancer interface {

--- a/pkg/failuredomains/balancer.go
+++ b/pkg/failuredomains/balancer.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package failuredomains
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"k8s.io/utils/pointer"
+	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
+	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type Balancer interface {
+	Assign(ctx context.Context, csMachine *infrav1.CloudStackMachine, capiMachine *clusterv1.Machine, fds []infrav1.CloudStackFailureDomainSpec) error
+}
+
+func NewFailureDomainBalancer(csClientFactory ClientFactory) Balancer {
+	return newReassigningFailureDomainBalancer(newFallingBackFailureDomainBalancer(
+		newFreeIPValidatingFailureDomainBalancer(csClientFactory),
+		newRandomFailureDomainBalancer(),
+	))
+}
+
+type reassigningFailureDomainBalancer struct {
+	delegate Balancer
+}
+
+func newReassigningFailureDomainBalancer(delegate Balancer) Balancer {
+	return &reassigningFailureDomainBalancer{delegate}
+}
+
+func (r *reassigningFailureDomainBalancer) Assign(ctx context.Context, csMachine *infrav1.CloudStackMachine, capiMachine *clusterv1.Machine, fds []infrav1.CloudStackFailureDomainSpec) error {
+	if csMachine.DeletionTimestamp != nil {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("Checking failure domain for machine", "machineHasFailed", csMachine.HasFailed(), "currentFailureDomain", csMachine.Spec.FailureDomainName)
+
+	if csMachine.Spec.FailureDomainName != "" && !csMachine.HasFailed() {
+		return nil
+	}
+
+	if capiMachineHasFailureDomain(capiMachine) && !csMachine.HasFailed() {
+		csMachine.Spec.FailureDomainName = *capiMachine.Spec.FailureDomain
+		assignFailureDomainLabel(csMachine, capiMachine)
+	} else if err := r.delegate.Assign(ctx, csMachine, capiMachine, fds); err != nil {
+		return err
+	}
+
+	if capiMachineHasFailureDomain(capiMachine) && csMachine.HasFailed() {
+		capiMachine.Spec.FailureDomain = pointer.String(csMachine.Spec.FailureDomainName)
+	}
+
+	return nil
+}
+
+type fallingBackFailureDomainBalancer struct {
+	primary  Balancer
+	fallback Balancer
+}
+
+func newFallingBackFailureDomainBalancer(primary Balancer, fallback Balancer) Balancer {
+	return &fallingBackFailureDomainBalancer{primary, fallback}
+}
+
+func (f *fallingBackFailureDomainBalancer) Assign(ctx context.Context, csMachine *infrav1.CloudStackMachine, capiMachine *clusterv1.Machine, fds []infrav1.CloudStackFailureDomainSpec) error {
+	if err := f.primary.Assign(ctx, csMachine, capiMachine, fds); err != nil {
+		logger := log.FromContext(ctx)
+		logger.Info("Unable to assign failure domain, falling back to the secondary balancer", "error", err)
+		return f.fallback.Assign(ctx, csMachine, capiMachine, fds)
+	}
+
+	return nil
+}
+
+type zoneIPCounts struct {
+	name        string
+	zoneName    string
+	networkName string
+	totalIPs    int
+	freeIPs     int
+}
+
+type randomFailureDomainBalancer struct {
+}
+
+func newRandomFailureDomainBalancer() Balancer {
+	return &randomFailureDomainBalancer{}
+}
+
+func (r *randomFailureDomainBalancer) Assign(_ context.Context, csMachine *infrav1.CloudStackMachine, capiMachine *clusterv1.Machine, fds []infrav1.CloudStackFailureDomainSpec) error {
+	randNum := rand.Int() % len(fds) // #nosec G404 -- weak crypt rand doesn't matter here.
+	csMachine.Spec.FailureDomainName = fds[randNum].Name
+	assignFailureDomainLabel(csMachine, capiMachine)
+
+	return nil
+}
+
+type freeIPValidatingFailureDomainBalancer struct {
+	csClientFactory ClientFactory
+}
+
+func newFreeIPValidatingFailureDomainBalancer(csClientFactory ClientFactory) Balancer {
+	return &freeIPValidatingFailureDomainBalancer{csClientFactory: csClientFactory}
+}
+
+type networkKey string
+
+func (b *freeIPValidatingFailureDomainBalancer) Assign(ctx context.Context, csMachine *infrav1.CloudStackMachine, capiMachine *clusterv1.Machine, fds []infrav1.CloudStackFailureDomainSpec) error {
+	networkAndZones, err := b.discoverFreeIps(ctx, fds)
+	if err != nil {
+		return err
+	}
+
+	zonesWithMostIps := findNetworkWithFreeIps(networkAndZones)
+	if len(zonesWithMostIps) > 0 {
+		randNum := rand.Int() % len(zonesWithMostIps) // #nosec G404 -- weak crypt rand doesn't matter here.
+		selectedZone := zonesWithMostIps[randNum]
+		csMachine.Spec.FailureDomainName = selectedZone.name
+		assignFailureDomainLabel(csMachine, capiMachine)
+	}
+
+	if csMachine.Spec.FailureDomainName == "" {
+		return fmt.Errorf("failed to assign failure domain, no failure domain with free IP addresses found")
+	}
+
+	return nil
+}
+
+func (b *freeIPValidatingFailureDomainBalancer) discoverFreeIps(ctx context.Context, fds []infrav1.CloudStackFailureDomainSpec) (map[networkKey][]zoneIPCounts, error) {
+	counts := map[networkKey][]zoneIPCounts{}
+
+	logger := log.FromContext(ctx)
+	logger.Info("Finding failure domains with most free IPs", "fds", fds)
+
+	for _, fd := range fds {
+		fdSpec := fd
+
+		_, csUser, err := b.csClientFactory.GetCloudClientAndUser(ctx, &fdSpec)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get CS client for failure domain %s: %sv", fd.Name, err)
+		}
+
+		network := fd.Zone.Network.DeepCopy()
+		if network.ID == "" {
+			if err := csUser.ResolveNetwork(network); err != nil {
+				return nil, fmt.Errorf("failed to resolve failure domain network %s: %sv", fd.Name, err)
+			}
+		}
+
+		logger.Info("Resolved failure domain network", "network", network)
+		if network.Type == cloud.NetworkTypeIsolated {
+			continue
+		}
+
+		addresses, err := csUser.GetPublicIPs(network)
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine free IP addressed for failure domain %s: %w", fd.Name, err)
+		}
+
+		countSummary := zoneIPCounts{
+			name:        fd.Name,
+			zoneName:    fd.Zone.Name,
+			networkName: network.Name,
+			totalIPs:    len(addresses),
+			freeIPs:     countFreeIps(addresses),
+		}
+		logger.Info("Resolved failure domain network IP count summary", "domain", fd.Name, "totalIPs", countSummary.totalIPs, "freeIPs", countSummary.freeIPs)
+
+		key := networkKey(network.Name)
+		if _, ok := counts[key]; !ok {
+			counts[key] = []zoneIPCounts{}
+		}
+		counts[key] = append(counts[key], countSummary)
+	}
+
+	return counts, nil
+}
+
+func findNetworkWithFreeIps(counts map[networkKey][]zoneIPCounts) []zoneIPCounts {
+	var keyWithMaxFreeIps networkKey
+	var maxFreeIps int
+
+	for key, cs := range counts {
+		for _, c := range cs {
+			if c.freeIPs > maxFreeIps {
+				maxFreeIps = c.freeIPs
+				keyWithMaxFreeIps = key
+			}
+		}
+	}
+
+	return counts[keyWithMaxFreeIps]
+}
+
+func countFreeIps(addresses []*cloudstack.PublicIpAddress) int {
+	free := 0
+	for _, address := range addresses {
+		if address.State == "Free" {
+			free++
+		}
+	}
+	return free
+}
+
+func capiMachineHasFailureDomain(capiMachine *clusterv1.Machine) bool {
+	return capiMachine != nil && capiMachine.Spec.FailureDomain != nil &&
+		(util.IsControlPlaneMachine(capiMachine) || // Is control plane machine -- CAPI will specify.
+			*capiMachine.Spec.FailureDomain != "") // Or potentially another machine controller specified.
+}
+
+func assignFailureDomainLabel(csMachine *infrav1.CloudStackMachine, capiMachine *clusterv1.Machine) {
+	if csMachine.Labels == nil {
+		csMachine.Labels = map[string]string{}
+	}
+	csMachine.Labels[infrav1.FailureDomainLabelName] = infrav1.FailureDomainHashedMetaName(csMachine.Spec.FailureDomainName, capiMachine.Spec.ClusterName)
+}

--- a/pkg/failuredomains/balancer_test.go
+++ b/pkg/failuredomains/balancer_test.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package failuredomains
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
+	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
+	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/mocks"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+var _ = Describe("Load Balancer", func() {
+
+	var (
+		mockCtrl     *gomock.Controller
+		mockCSClient *mocks.MockClient
+
+		ctx         context.Context
+		capiMachine *clusterv1.Machine
+		csMachine   *infrav1.CloudStackMachine
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockCSClient = mocks.NewMockClient(mockCtrl)
+
+		ctx = context.TODO()
+		capiMachine = &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "a-machine",
+				Namespace: "default",
+			},
+			Spec: clusterv1.MachineSpec{},
+		}
+		csMachine = &infrav1.CloudStackMachine{
+			Spec: infrav1.CloudStackMachineSpec{},
+		}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	Context("reassigning balancer", func() {
+		It("assign a failure domain when NOT already assigned", func() {
+			balancer := newReassigningFailureDomainBalancer(newRandomFailureDomainBalancer())
+
+			fds := []infrav1.CloudStackFailureDomainSpec{
+				{Name: "zone-a"},
+			}
+
+			Expect(balancer.Assign(ctx, csMachine, capiMachine, fds)).Should(Succeed())
+			Expect(csMachine.Spec.FailureDomainName).ShouldNot(BeEmpty())
+		})
+
+		It("re-assign a failure domain when already assigned but machine has failed to launch", func() {
+			delegate := &fakeBalancer{"zone-b"}
+			balancer := newReassigningFailureDomainBalancer(delegate)
+
+			fds := []infrav1.CloudStackFailureDomainSpec{
+				{Name: "zone-a"},
+				{Name: "zone-b"},
+			}
+
+			csMachine.Spec.FailureDomainName = fds[0].Name
+			csMachine.MarkAsFailed()
+
+			Expect(balancer.Assign(ctx, csMachine, capiMachine, fds)).Should(Succeed())
+			Expect(csMachine.Spec.FailureDomainName).Should(Equal(fds[1].Name))
+		})
+
+		It("re-assign a failure domain AND update CAPI machine when already assigned but machine has failed to launch", func() {
+			delegate := &fakeBalancer{"zone-b"}
+
+			balancer := newReassigningFailureDomainBalancer(delegate)
+
+			fds := []infrav1.CloudStackFailureDomainSpec{
+				{Name: "zone-a"},
+				{Name: "zone-b"},
+			}
+
+			capiMachine.Spec.FailureDomain = pointer.String(fds[0].Name)
+			csMachine.Spec.FailureDomainName = fds[0].Name
+			csMachine.MarkAsFailed()
+
+			Expect(balancer.Assign(ctx, csMachine, capiMachine, fds)).Should(Succeed())
+			Expect(csMachine.Spec.FailureDomainName).Should(Equal(fds[1].Name))
+		})
+
+		It("should NOT re-assign a failure domain when already assigned", func() {
+			balancer := newReassigningFailureDomainBalancer(newRandomFailureDomainBalancer())
+
+			fds := []infrav1.CloudStackFailureDomainSpec{
+				{Name: "zone-a"},
+				{Name: "zone-b"},
+				{Name: "zone-c"},
+			}
+
+			csMachine.Spec.FailureDomainName = fds[0].Name
+
+			Expect(balancer.Assign(ctx, csMachine, capiMachine, fds)).Should(Succeed())
+			Expect(csMachine.Spec.FailureDomainName).Should(Equal(fds[0].Name))
+		})
+	})
+
+	Context("falling back balancer", func() {
+		It("fallback to secondary balancer", func() {
+			balancer := newFallingBackFailureDomainBalancer(
+				newFailingDomainBalancer(fmt.Errorf("failed to assign a failure domain")),
+				newRandomFailureDomainBalancer(),
+			)
+
+			fds := []infrav1.CloudStackFailureDomainSpec{
+				{Name: "zone-a"},
+				{Name: "zone-b"},
+			}
+
+			Expect(balancer.Assign(ctx, csMachine, capiMachine, fds)).Should(Succeed())
+			Expect(csMachine.Spec.FailureDomainName).ShouldNot(BeEmpty())
+		})
+
+		It("should NOT assign a failure domain because all balancers failed", func() {
+			balancer := newFallingBackFailureDomainBalancer(
+				newFailingDomainBalancer(fmt.Errorf("primary failed to assign a failure domain")),
+				newFailingDomainBalancer(fmt.Errorf("secondary failed to assign a failure domain")),
+			)
+
+			fds := []infrav1.CloudStackFailureDomainSpec{
+				{Name: "zone-a"},
+				{Name: "zone-b"},
+			}
+
+			Expect(balancer.Assign(ctx, csMachine, capiMachine, fds)).Should(MatchError("secondary failed to assign a failure domain"))
+		})
+	})
+
+	Context("free ip addresses validating balancer", func() {
+		network1 := "172.16.0.0/24"
+		network2 := "172.16.0.1/24"
+
+		It("assign a failure domain with more free IPs", func() {
+			balancer := newFreeIPValidatingFailureDomainBalancer(&fakeFailureDomainClientFactory{mockCSClient})
+
+			fds := []infrav1.CloudStackFailureDomainSpec{
+				{Name: "zone-a", Zone: infrav1.CloudStackZoneSpec{Network: infrav1.Network{Name: network1}}},
+				{Name: "zone-b", Zone: infrav1.CloudStackZoneSpec{Network: infrav1.Network{Name: network2}}},
+			}
+
+			// zone-a
+			mockCSClient.EXPECT().ResolveNetwork(&fds[0].Zone.Network)
+			mockCSClient.EXPECT().GetPublicIPs(&fds[0].Zone.Network).Return([]*cloudstack.PublicIpAddress{
+				{State: "Allocated"},
+				{State: "Free"},
+			}, nil)
+
+			// zone-b
+			mockCSClient.EXPECT().ResolveNetwork(&fds[1].Zone.Network)
+			mockCSClient.EXPECT().GetPublicIPs(&fds[1].Zone.Network).Return([]*cloudstack.PublicIpAddress{
+				{State: "Allocated"},
+				{State: "Free"},
+				{State: "Free"},
+			}, nil)
+
+			Expect(balancer.Assign(ctx, csMachine, capiMachine, fds)).Should(Succeed())
+			Expect(csMachine.Spec.FailureDomainName).Should(Equal("zone-b"))
+		})
+
+		It("assign a failure domain when there are zones with shared networks", func() {
+			balancer := newFreeIPValidatingFailureDomainBalancer(&fakeFailureDomainClientFactory{mockCSClient})
+
+			fds := []infrav1.CloudStackFailureDomainSpec{
+				{Name: "zone-a-net-1", Zone: infrav1.CloudStackZoneSpec{Network: infrav1.Network{Name: network1}}},
+				{Name: "zone-a-net-2", Zone: infrav1.CloudStackZoneSpec{Network: infrav1.Network{Name: network2}}},
+				{Name: "zone-b-net-1", Zone: infrav1.CloudStackZoneSpec{Network: infrav1.Network{Name: network1}}},
+				{Name: "zone-b-net-2", Zone: infrav1.CloudStackZoneSpec{Network: infrav1.Network{Name: network2}}},
+			}
+
+			// zone-a
+			mockCSClient.EXPECT().ResolveNetwork(&fds[0].Zone.Network).Times(2)
+			mockCSClient.EXPECT().GetPublicIPs(&fds[0].Zone.Network).Return([]*cloudstack.PublicIpAddress{
+				{State: "Allocated"},
+				{State: "Free"},
+			}, nil).Times(2)
+
+			// zone-b
+			mockCSClient.EXPECT().ResolveNetwork(&fds[1].Zone.Network).Times(2)
+			mockCSClient.EXPECT().GetPublicIPs(&fds[1].Zone.Network).Return([]*cloudstack.PublicIpAddress{
+				{State: "Allocated"},
+				{State: "Free"},
+				{State: "Free"},
+			}, nil).Times(2)
+
+			Expect(balancer.Assign(ctx, csMachine, capiMachine, fds)).Should(Succeed())
+			Expect(strings.HasSuffix(csMachine.Spec.FailureDomainName, "net-2")).Should(BeTrue())
+		})
+
+		It("assign the first non-zero failure domain with free IPs", func() {
+			balancer := newFreeIPValidatingFailureDomainBalancer(&fakeFailureDomainClientFactory{mockCSClient})
+
+			fds := []infrav1.CloudStackFailureDomainSpec{
+				{Name: "zone-a", Zone: infrav1.CloudStackZoneSpec{Network: infrav1.Network{Name: network1}}},
+				{Name: "zone-b", Zone: infrav1.CloudStackZoneSpec{Network: infrav1.Network{Name: network2}}},
+			}
+
+			// zone-a
+			mockCSClient.EXPECT().ResolveNetwork(&fds[0].Zone.Network)
+			mockCSClient.EXPECT().GetPublicIPs(&fds[0].Zone.Network).Return([]*cloudstack.PublicIpAddress{
+				{State: "Free"},
+			}, nil)
+
+			// zone-b
+			mockCSClient.EXPECT().ResolveNetwork(&fds[1].Zone.Network)
+			mockCSClient.EXPECT().GetPublicIPs(&fds[1].Zone.Network).Return([]*cloudstack.PublicIpAddress{
+				{State: "Free"},
+			}, nil)
+
+			Expect(balancer.Assign(ctx, csMachine, capiMachine, fds)).Should(Succeed())
+			Expect(csMachine.Spec.FailureDomainName).Should(Equal("zone-a"))
+		})
+
+		It("should NOT assign a failure domain because all IPs are allocated", func() {
+			balancer := newFreeIPValidatingFailureDomainBalancer(&fakeFailureDomainClientFactory{mockCSClient})
+
+			fds := []infrav1.CloudStackFailureDomainSpec{
+				{Name: "zone-a", Zone: infrav1.CloudStackZoneSpec{Network: infrav1.Network{Name: network1}}},
+				{Name: "zone-b", Zone: infrav1.CloudStackZoneSpec{Network: infrav1.Network{Name: network2}}},
+			}
+
+			// zone-a
+			mockCSClient.EXPECT().ResolveNetwork(&fds[0].Zone.Network)
+			mockCSClient.EXPECT().GetPublicIPs(&fds[0].Zone.Network).Return([]*cloudstack.PublicIpAddress{
+				{State: "Allocated"},
+			}, nil)
+
+			// zone-b
+			mockCSClient.EXPECT().ResolveNetwork(&fds[1].Zone.Network)
+			mockCSClient.EXPECT().GetPublicIPs(&fds[1].Zone.Network).Return([]*cloudstack.PublicIpAddress{
+				{State: "Allocated"},
+			}, nil)
+
+			Expect(balancer.Assign(ctx, csMachine, capiMachine, fds)).
+				Should(MatchError("failed to assign failure domain, no failure domain with free IP addresses found"))
+		})
+	})
+
+	Context("random balancer", func() {
+		It("assign random failure domain", func() {
+			balancer := newRandomFailureDomainBalancer()
+
+			fds := []infrav1.CloudStackFailureDomainSpec{
+				{Name: "zone-a"},
+			}
+
+			Expect(balancer.Assign(ctx, csMachine, capiMachine, fds)).Should(Succeed())
+			Expect(csMachine.Spec.FailureDomainName).Should(Equal("zone-a"))
+		})
+	})
+
+})
+
+type fakeFailureDomainClientFactory struct {
+	cloud.Client
+}
+
+func (f *fakeFailureDomainClientFactory) GetCloudClientAndUser(_ context.Context, _ *infrav1.CloudStackFailureDomainSpec) (csClient cloud.Client, csUser cloud.Client, err error) {
+	return f, f, nil
+}
+
+type failingDomainBalancer struct {
+	failure error
+}
+
+func newFailingDomainBalancer(failure error) Balancer {
+	return &failingDomainBalancer{failure}
+}
+
+func (n *failingDomainBalancer) Assign(_ context.Context, _ *infrav1.CloudStackMachine, _ *clusterv1.Machine, _ []infrav1.CloudStackFailureDomainSpec) error {
+	return n.failure
+}
+
+type fakeBalancer struct {
+	failureDomainName string
+}
+
+func (f *fakeBalancer) Assign(_ context.Context, csMachine *infrav1.CloudStackMachine, _ *clusterv1.Machine, _ []infrav1.CloudStackFailureDomainSpec) error {
+	csMachine.Spec.FailureDomainName = f.failureDomainName
+
+	return nil
+}

--- a/pkg/failuredomains/balancer_test.go
+++ b/pkg/failuredomains/balancer_test.go
@@ -27,10 +27,11 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/mocks"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 var _ = Describe("Load Balancer", func() {

--- a/pkg/failuredomains/client.go
+++ b/pkg/failuredomains/client.go
@@ -51,7 +51,7 @@ func (f *baseClientFactory) GetCloudClientAndUser(ctx context.Context, fdSpec *i
 
 	clientConfig := &corev1.ConfigMap{}
 	key = client.ObjectKey{Name: cloud.ClientConfigMapName, Namespace: cloud.ClientConfigMapNamespace}
-	_ = f.Get(ctx, key, clientConfig)
+	_ = f.Get(ctx, key, clientConfig) // client config is optional, hence we can ignore the error
 
 	csClient, err = cloud.NewClientFromK8sSecret(endpointCredentials, clientConfig)
 	if err != nil {

--- a/pkg/failuredomains/client.go
+++ b/pkg/failuredomains/client.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package failuredomains
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
+	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ClientFactory interface {
+	GetCloudClientAndUser(ctx context.Context, fdSpec *infrav1.CloudStackFailureDomainSpec) (csClient cloud.Client, csUser cloud.Client, err error)
+}
+
+func NewClientFactory(k8sClient client.Client) ClientFactory {
+	return newBaseClientFactory(k8sClient)
+}
+
+type baseClientFactory struct {
+	client.Client
+}
+
+func newBaseClientFactory(k8sClient client.Client) ClientFactory {
+	return &baseClientFactory{k8sClient}
+}
+
+func (f *baseClientFactory) GetCloudClientAndUser(ctx context.Context, fdSpec *infrav1.CloudStackFailureDomainSpec) (csClient cloud.Client, csUser cloud.Client, err error) {
+	endpointCredentials := &corev1.Secret{}
+	key := client.ObjectKey{Name: fdSpec.ACSEndpoint.Name, Namespace: fdSpec.ACSEndpoint.Namespace}
+	if err := f.Get(ctx, key, endpointCredentials); err != nil {
+		return nil, nil, errors.Wrapf(err, "getting ACSEndpoint secret with ref: %v", fdSpec.ACSEndpoint)
+	}
+
+	clientConfig := &corev1.ConfigMap{}
+	key = client.ObjectKey{Name: cloud.ClientConfigMapName, Namespace: cloud.ClientConfigMapNamespace}
+	_ = f.Get(ctx, key, clientConfig)
+
+	csClient, err = cloud.NewClientFromK8sSecret(endpointCredentials, clientConfig)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "parsing ACSEndpoint secret with ref: %v", fdSpec.ACSEndpoint)
+	}
+
+	if fdSpec.Account != "" { // Get CloudStack Client per Account and Domain.
+		csClientInDomain, err := csClient.NewClientInDomainAndAccount(fdSpec.Domain, fdSpec.Account)
+		if err != nil {
+			return nil, nil, err
+		}
+		csUser = csClientInDomain
+	} else { // Set r.CSUser CloudStack Client to r.CSClient since Account & Domain weren't provided.
+		csUser = csClient
+	}
+
+	return csClient, csUser, nil
+}

--- a/pkg/failuredomains/client.go
+++ b/pkg/failuredomains/client.go
@@ -21,9 +21,10 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ClientFactory interface {

--- a/pkg/failuredomains/client_test.go
+++ b/pkg/failuredomains/client_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package failuredomains
+
+import (
+	"context"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
+	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
+	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Client Factory", func() {
+	var (
+		k8sClient  client.Client
+		mockCtrl   *gomock.Controller
+		mockClient *cloudstack.CloudStackClient
+
+		us *cloudstack.MockUserServiceIface
+		ds *cloudstack.MockDomainServiceIface
+		as *cloudstack.MockAccountServiceIface
+
+		ctx                 context.Context
+		endpointCredentials *corev1.Secret
+		clientConfig        *corev1.ConfigMap
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockClient = cloudstack.NewMockClient(mockCtrl)
+
+		us = mockClient.User.(*cloudstack.MockUserServiceIface)
+		ds = mockClient.Domain.(*cloudstack.MockDomainServiceIface)
+		as = mockClient.Account.(*cloudstack.MockAccountServiceIface)
+
+		ctx = context.TODO()
+
+		dummies.SetDummyUserVars()
+		dummies.AccountName = "test-account"
+
+		endpointCredentials = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "zone-a-creds",
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"api-key":    []byte(dummies.Apikey),
+				"secret-key": []byte(dummies.SecretKey),
+				"api-url":    []byte("http://1.2.3.4:8080/client/api"),
+				"verify-ssl": []byte("false"),
+			},
+		}
+
+		clientConfig = &corev1.ConfigMap{}
+
+		cloud.NewAsyncClient = func(apiurl, apikey, secret string, verifyssl bool, options ...cloudstack.ClientOption) *cloudstack.CloudStackClient {
+			return mockClient
+		}
+		cloud.NewClient = func(apiurl, apikey, secret string, verifyssl bool, options ...cloudstack.ClientOption) *cloudstack.CloudStackClient {
+			return mockClient
+		}
+	})
+
+	BeforeEach(func() {
+		asp := &cloudstack.ListAccountsParams{}
+		as.EXPECT().NewListAccountsParams().Return(asp).AnyTimes()
+		as.EXPECT().ListAccounts(asp).Return(&cloudstack.ListAccountsResponse{Count: 1, Accounts: []*cloudstack.Account{{
+			Id:   dummies.AccountID,
+			Name: dummies.AccountName,
+		}}}, nil).AnyTimes()
+
+		fakeListParams := &cloudstack.ListUsersParams{}
+		fakeUser := &cloudstack.User{
+			Id:      dummies.UserID,
+			Account: dummies.AccountName,
+			Domain:  dummies.DomainName,
+		}
+		us.EXPECT().NewListUsersParams().Return(fakeListParams).AnyTimes()
+		us.EXPECT().ListUsers(fakeListParams).Return(&cloudstack.ListUsersResponse{
+			Count: 1, Users: []*cloudstack.User{fakeUser},
+		}, nil).AnyTimes()
+
+		ukp := &cloudstack.GetUserKeysParams{}
+		us.EXPECT().NewGetUserKeysParams(gomock.Any()).Return(ukp).AnyTimes()
+		us.EXPECT().GetUserKeys(ukp).Return(&cloudstack.GetUserKeysResponse{
+			Apikey:    dummies.Apikey,
+			Secretkey: dummies.SecretKey,
+		}, nil).AnyTimes()
+
+		dsp := &cloudstack.ListDomainsParams{}
+		ds.EXPECT().NewListDomainsParams().Return(dsp).AnyTimes()
+		ds.EXPECT().ListDomains(dsp).Return(&cloudstack.ListDomainsResponse{Count: 1, Domains: []*cloudstack.Domain{{
+			Id:   dummies.DomainID,
+			Name: dummies.DomainName,
+			Path: dummies.DomainPath,
+		}}}, nil).AnyTimes()
+	})
+
+	Context("base factory", func() {
+		It("create cloudstack client and user", func() {
+			k8sClient = fake.NewClientBuilder().
+				WithObjects(endpointCredentials, clientConfig).
+				Build()
+
+			fdSpec := &infrav1.CloudStackFailureDomainSpec{Name: "zone-a", ACSEndpoint: corev1.SecretReference{
+				Name:      endpointCredentials.Name,
+				Namespace: endpointCredentials.Namespace,
+			}}
+
+			factory := newBaseClientFactory(k8sClient)
+
+			csClient, csUser, err := factory.GetCloudClientAndUser(ctx, fdSpec)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(csClient).ShouldNot(BeNil())
+			Expect(csUser).ShouldNot(BeNil())
+		})
+
+		It("create cloudstack client and user for a specific account in the domain", func() {
+			k8sClient = fake.NewClientBuilder().
+				WithObjects(endpointCredentials, clientConfig).
+				Build()
+
+			fdSpec := &infrav1.CloudStackFailureDomainSpec{Name: "zone-a", Account: dummies.AccountName, ACSEndpoint: corev1.SecretReference{
+				Name:      endpointCredentials.Name,
+				Namespace: endpointCredentials.Namespace,
+			}}
+			factory := newBaseClientFactory(k8sClient)
+
+			csClient, csUser, err := factory.GetCloudClientAndUser(ctx, fdSpec)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(csClient).ShouldNot(BeNil())
+			Expect(csUser).ShouldNot(BeNil())
+		})
+	})
+
+})

--- a/pkg/failuredomains/client_test.go
+++ b/pkg/failuredomains/client_test.go
@@ -25,11 +25,12 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Client Factory", func() {

--- a/pkg/failuredomains/failuredomains_suite_test.go
+++ b/pkg/failuredomains/failuredomains_suite_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package failuredomains_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestFailuredomains(t *testing.T) {
+	RegisterFailHandler(Fail)
+	Expect(capiv1.AddToScheme(scheme.Scheme)).Should(Succeed())
+
+	RunSpecs(t, "Failuredomains Suite")
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,8 +19,9 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	cserrors "sigs.k8s.io/cluster-api-provider-cloudstack/pkg/errors"
 	crtlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	cserrors "sigs.k8s.io/cluster-api-provider-cloudstack/pkg/errors"
 )
 
 // AcsCustomMetrics encapsulates all CloudStack custom metrics defined for the controller.


### PR DESCRIPTION
*Issue #352*

*Description of changes:* CAPC chooses a [random failure domain](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/blob/d597e8056e82ac6418171e66fa2532b2daaef987/controllers/cloudstackmachine_controller.go#L185) to deploy worker machines. When this VM deploy fails, irrespective of the type of error, CAPC will keep re-attempting to deploy a VM until CAPI replaces the owner machine. This change introduces a failure domain balancer with fallback mechanism, primary balancer selects failure domain from network with most free IPs and if it fails it fallbacks to random failure domain selection.

*Testing performed:* 
`make test`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->