### PR TITLE
Allow cluster creation by a normal ACS user

### DIFF
--- a/docs/book/src/topics/cloudstack-permissions.md
+++ b/docs/book/src/topics/cloudstack-permissions.md
@@ -1,6 +1,6 @@
 # CloudStack Permissions for CAPC
 
-The account that CAPC runs under must minimally be a Domain Admin type account with a role offering the following permissions
+The account that CAPC runs under must minimally be a User type account with a role offering the following permissions
 
 * assignToLoadBalancerRule
 * associateIpAddress
@@ -19,7 +19,6 @@ The account that CAPC runs under must minimally be a Domain Admin type account w
 * listAccounts
 * listAffinityGroups
 * listDiskOfferings
-* listDomains
 * listLoadBalancerRuleInstances
 * listLoadBalancerRules
 * listNetworkOfferings
@@ -38,5 +37,7 @@ The account that CAPC runs under must minimally be a Domain Admin type account w
 * startVirtualMachine
 * stopVirtualMachine
 * updateVMAffinityGroup
+
+> Note: If the user doesn't have permissions to expunge the VM, it will be left in a destroyed state. The user will need to manually expunge the VM.
 
 This permission set has been verified to successfully run the CAPC E2E test suite (Oct 11, 2022).

--- a/pkg/cloud/user_credentials.go
+++ b/pkg/cloud/user_credentials.go
@@ -152,7 +152,8 @@ func (c *client) ResolveDomain(domain *Domain) error {
 // ResolveAccount resolves an account's information.
 func (c *client) ResolveAccount(account *Account) error {
 	// Resolve domain prior to any account resolution activity.
-	if err := c.ResolveDomain(&account.Domain); err != nil {
+	if err := c.ResolveDomain(&account.Domain); err != nil &&
+		!strings.Contains(err.Error(), "The API [listDomains] does not exist or is not available for the account Account") {
 		return errors.Wrapf(err, "resolving domain %s details", account.Domain.Name)
 	}
 


### PR DESCRIPTION
*Issue #, if available:* Fixes https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/issues/303

*Description of changes:*
* Domain information is not required for a normal user account. So, if the credentials don't have access to `listDomains`, it will no longer fail.
* If the user sets expunge to true when it doesn't have the capability, the request fails. This PR includes changes which first checks if the user has access to expunge volumes or not and then set the expunge parameter accordingly.

*Testing performed:*
Launched and removed a test cluster with a normal user account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->