### PR TITLE
Fix cks cluster sync for a normal user

### DIFF
--- a/pkg/cloud/cks_cluster.go
+++ b/pkg/cloud/cks_cluster.go
@@ -74,10 +74,11 @@ func (c *client) GetOrCreateCksCluster(cluster *clusterv1.Cluster, csCluster *in
 		if accountName == "" {
 			userParams := c.cs.User.NewGetUserParams(c.config.APIKey)
 			user, err := c.cs.User.GetUser(userParams)
-			if err != nil {
+			if err != nil && !strings.Contains(err.Error(), "does not exist or is not available for the account") {
 				return err
+			} else if err == nil {
+				accountName = user.Account
 			}
-			accountName = user.Account
 		}
 		// NewCreateKubernetesClusterParams(description string, kubernetesversionid string, name string, serviceofferingid string, size int64, zoneid string) *CreateKubernetesClusterParams
 		params := c.cs.Kubernetes.NewCreateKubernetesClusterParams(fmt.Sprintf("%s managed by CAPC", clusterName), "", clusterName, "", 0, fd.Zone.ID)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix CKS cluster sync for a normal user account. As of now, the request to create the cluster fails with  the below error:
```go
I0703 06:41:29.221156      14 base_reconciler.go:343] controllers/CKSClusterController "msg"="Failed creating ExternalManaged CKS cluster on CloudStack. error: CloudStack API error 432 (CSExceptionErrorCode: 9999): The API [getUser] does not exist or is not available for the account Account [{\"accountName\":\"ACSUser\",\"id\":4,\"uuid\":\"825b2028-c36a-4399-8560-442f5e587a2c\"}]. Requeuing." "name"="capc-cluster" "namespace"="default"
```


*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->