### PR TITLE
Fix linting issues reported by golanci-lint

### DIFF
--- a/api/v1beta1/cloudstackaffinitygroup_conversion.go
+++ b/api/v1beta1/cloudstackaffinitygroup_conversion.go
@@ -47,10 +47,8 @@ func (dst *CloudStackAffinityGroup) ConvertFrom(srcRaw conversion.Hub) error { /
 	}
 
 	// Preserve Hub data on down-conversion
-	if err := utilconversion.MarshalData(src, dst); err != nil {
-		return err
-	}
-	return nil
+	err := utilconversion.MarshalData(src, dst)
+	return err
 }
 
 func Convert_v1beta3_CloudStackAffinityGroupSpec_To_v1beta1_CloudStackAffinityGroupSpec(in *v1beta3.CloudStackAffinityGroupSpec, out *CloudStackAffinityGroupSpec, s machineryconversion.Scope) error { // nolint

--- a/api/v1beta1/cloudstackisolatednetwork_conversion.go
+++ b/api/v1beta1/cloudstackisolatednetwork_conversion.go
@@ -47,10 +47,8 @@ func (dst *CloudStackIsolatedNetwork) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	// Preserve Hub data on down-conversion
-	if err := utilconversion.MarshalData(src, dst); err != nil {
-		return err
-	}
-	return nil
+	err := utilconversion.MarshalData(src, dst)
+	return err
 }
 
 func Convert_v1beta3_CloudStackIsolatedNetworkSpec_To_v1beta1_CloudStackIsolatedNetworkSpec(in *v1beta3.CloudStackIsolatedNetworkSpec, out *CloudStackIsolatedNetworkSpec, s machineryconversion.Scope) error { // nolint

--- a/api/v1beta1/cloudstackmachine_conversion.go
+++ b/api/v1beta1/cloudstackmachine_conversion.go
@@ -56,10 +56,8 @@ func (dst *CloudStackMachine) ConvertFrom(srcRaw conversion.Hub) error { // noli
 	}
 
 	// Preserve Hub data on down-conversion
-	if err := utilconversion.MarshalData(src, dst); err != nil {
-		return err
-	}
-	return nil
+	err := utilconversion.MarshalData(src, dst)
+	return err
 }
 
 func Convert_v1beta3_CloudStackMachineSpec_To_v1beta1_CloudStackMachineSpec(in *v1beta3.CloudStackMachineSpec, out *CloudStackMachineSpec, s machineryconversion.Scope) error { // nolint

--- a/api/v1beta1/cloudstackmachine_types_test.go
+++ b/api/v1beta1/cloudstackmachine_types_test.go
@@ -17,30 +17,31 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta1"
-	"time"
 )
 
-var _ = Describe("CloudStackMachine types", func() {
+var _ = ginkgo.Describe("CloudStackMachine types", func() {
 	var cloudStackMachine infrav1.CloudStackMachine
 
-	BeforeEach(func() { // Reset test vars to initial state.
+	ginkgo.BeforeEach(func() { // Reset test vars to initial state.
 		cloudStackMachine = infrav1.CloudStackMachine{}
 	})
 
-	Context("When calculating time since state change", func() {
-		It("Return the correct value when the last state update time is known", func() {
+	ginkgo.Context("When calculating time since state change", func() {
+		ginkgo.It("Return the correct value when the last state update time is known", func() {
 			delta := time.Duration(10 * time.Minute)
 			lastUpdated := time.Now().Add(-delta)
 			cloudStackMachine.Status.InstanceStateLastUpdated = metav1.NewTime(lastUpdated)
-			Ω(cloudStackMachine.Status.TimeSinceLastStateChange()).Should(BeNumerically("~", delta, time.Second))
+			gomega.Expect(cloudStackMachine.Status.TimeSinceLastStateChange()).Should(gomega.BeNumerically("~", delta, time.Second))
 		})
 
-		It("Return a negative value when the last state update time is unknown", func() {
-			Ω(cloudStackMachine.Status.TimeSinceLastStateChange()).Should(BeNumerically("<", 0))
+		ginkgo.It("Return a negative value when the last state update time is unknown", func() {
+			gomega.Expect(cloudStackMachine.Status.TimeSinceLastStateChange()).Should(gomega.BeNumerically("<", 0))
 		})
 	})
 })

--- a/api/v1beta1/cloudstackmachinetemplate_conversion.go
+++ b/api/v1beta1/cloudstackmachinetemplate_conversion.go
@@ -53,10 +53,8 @@ func (dst *CloudStackMachineTemplate) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	// Preserve Hub data on down-conversion
-	if err := utilconversion.MarshalData(src, dst); err != nil {
-		return err
-	}
-	return nil
+	err := utilconversion.MarshalData(src, dst)
+	return err
 }
 
 func Convert_v1beta1_CloudStackMachineTemplateSpec_To_v1beta3_CloudStackMachineTemplateSpec(in *CloudStackMachineTemplateSpec, out *v1beta3.CloudStackMachineTemplateSpec, s machineryconversion.Scope) error { // nolint

--- a/api/v1beta1/conversion.go
+++ b/api/v1beta1/conversion.go
@@ -123,7 +123,7 @@ func GetFailureDomains(csCluster *CloudStackCluster) ([]v1beta3.CloudStackFailur
 // When upgrading cluster using eks-a, a secret named global will be created by eks-a, and it is used by following
 // method to get zoneID by calling cloudstack API.
 // When upgrading cluster using clusterctl directly, zoneID is fetched directly from kubernetes cluster in cloudstackzones.
-func GetDefaultFailureDomainName(namespace string, clusterName string, zoneID string, zoneName string) (string, error) {
+func GetDefaultFailureDomainName(namespace string, _ string, zoneID string, zoneName string) (string, error) {
 	if len(zoneID) > 0 {
 		return zoneID, nil
 	}

--- a/api/v1beta1/conversion_test.go
+++ b/api/v1beta1/conversion_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta1"
@@ -26,12 +26,12 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-var _ = Describe("Conversion", func() {
-	BeforeEach(func() { // Reset test vars to initial state.
+var _ = ginkgo.Describe("Conversion", func() {
+	ginkgo.BeforeEach(func() { // Reset test vars to initial state.
 	})
 
-	Context("GetFailureDomains function", func() {
-		It("Converts v1beta1 cluster spec to v1beta3 failure domains", func() {
+	ginkgo.Context("GetFailureDomains function", func() {
+		ginkgo.It("Converts v1beta1 cluster spec to v1beta3 failure domains", func() {
 			csCluster := &v1beta1.CloudStackCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cluster1",
@@ -71,13 +71,13 @@ var _ = Describe("Conversion", func() {
 					},
 				},
 			}
-			Ω(err).ShouldNot(HaveOccurred())
-			Ω(failureDomains).Should(Equal(expectedResult))
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(failureDomains).Should(gomega.Equal(expectedResult))
 		})
 	})
 
-	Context("v1beta3 to v1beta1 function", func() {
-		It("Converts v1beta3 cluster spec to v1beta1 zone based cluster spec", func() {
+	ginkgo.Context("v1beta3 to v1beta1 function", func() {
+		ginkgo.It("Converts v1beta3 cluster spec to v1beta1 zone based cluster spec", func() {
 			csCluster := &v1beta3.CloudStackCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cluster1",
@@ -132,11 +132,11 @@ var _ = Describe("Conversion", func() {
 				Status: v1beta1.CloudStackClusterStatus{},
 			}
 
-			Ω(err).ShouldNot(HaveOccurred())
-			Ω(converted).Should(Equal(expectedResult))
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(converted).Should(gomega.Equal(expectedResult))
 		})
 
-		It("Returns error when len(failureDomains) < 1", func() {
+		ginkgo.It("Returns error when len(failureDomains) < 1", func() {
 			csCluster := &v1beta3.CloudStackCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cluster1",
@@ -151,7 +151,7 @@ var _ = Describe("Conversion", func() {
 				Status: v1beta3.CloudStackClusterStatus{},
 			}
 			err := v1beta1.Convert_v1beta3_CloudStackCluster_To_v1beta1_CloudStackCluster(csCluster, nil, nil)
-			Ω(err).Should(HaveOccurred())
+			gomega.Expect(err).Should(gomega.HaveOccurred())
 		})
 	})
 })

--- a/api/v1beta2/cloudstackmachine_types_test.go
+++ b/api/v1beta2/cloudstackmachine_types_test.go
@@ -20,11 +20,11 @@ import (
 	"k8s.io/utils/pointer"
 	capcv1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta2"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
-var _ = Describe("CloudStackMachineConfig_CompressUserdata", func() {
+var _ = ginkgo.Describe("CloudStackMachineConfig_CompressUserdata", func() {
 	for _, tc := range []struct {
 		Name    string
 		Machine capcv1.CloudStackMachine
@@ -59,9 +59,9 @@ var _ = Describe("CloudStackMachineConfig_CompressUserdata", func() {
 		},
 	} {
 		tc := tc
-		It(tc.Name, func() {
+		ginkgo.It(tc.Name, func() {
 			result := tc.Machine.CompressUserdata()
-			Expect(result).To(Equal(tc.Expect))
+			gomega.Expect(result).To(gomega.Equal(tc.Expect))
 		})
 	}
 })

--- a/api/v1beta3/cloudstackcluster_webhook_test.go
+++ b/api/v1beta3/cloudstackcluster_webhook_test.go
@@ -19,66 +19,66 @@ package v1beta3_test
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
 )
 
-var _ = Describe("CloudStackCluster webhooks", func() {
+var _ = ginkgo.Describe("CloudStackCluster webhooks", func() {
 	var ctx context.Context
 	forbiddenRegex := "admission webhook.*denied the request.*Forbidden\\: %s"
 	requiredRegex := "admission webhook.*denied the request.*Required value\\: %s"
 
-	BeforeEach(func() { // Reset test vars to initial state.
+	ginkgo.BeforeEach(func() { // Reset test vars to initial state.
 		ctx = context.Background()
 		dummies.SetDummyVars()                       // Reset cluster var.
 		_ = k8sClient.Delete(ctx, dummies.CSCluster) // Delete any remnants.
 		dummies.SetDummyVars()                       // Reset again since the k8s client can set this on delete.
 	})
 
-	Context("When creating a CloudStackCluster", func() {
-		It("Should accept a CloudStackCluster with all attributes present", func() {
-			Ω(k8sClient.Create(ctx, dummies.CSCluster)).Should(Succeed())
+	ginkgo.Context("When creating a CloudStackCluster", func() {
+		ginkgo.It("Should accept a CloudStackCluster with all attributes present", func() {
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSCluster)).Should(gomega.Succeed())
 		})
 
-		It("Should reject a CloudStackCluster with missing Zones.Network attribute", func() {
+		ginkgo.It("Should reject a CloudStackCluster with missing Zones.Network attribute", func() {
 			dummies.CSCluster.Spec.FailureDomains = []infrav1.CloudStackFailureDomainSpec{{}}
 			dummies.CSCluster.Spec.FailureDomains[0].Zone.Name = "ZoneWNoNetwork"
-			Ω(k8sClient.Create(ctx, dummies.CSCluster)).Should(
-				MatchError(MatchRegexp(requiredRegex, "each Zone requires a Network specification")))
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSCluster)).Should(
+				gomega.MatchError(gomega.MatchRegexp(requiredRegex, "each Zone requires a Network specification")))
 		})
 
-		It("Should reject a CloudStackCluster with missing Zone attribute", func() {
+		ginkgo.It("Should reject a CloudStackCluster with missing Zone attribute", func() {
 			dummies.CSCluster.Spec.FailureDomains[0].Zone = infrav1.CloudStackZoneSpec{}
-			Ω(k8sClient.Create(ctx, dummies.CSCluster)).Should(MatchError(MatchRegexp(requiredRegex,
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSCluster)).Should(gomega.MatchError(gomega.MatchRegexp(requiredRegex,
 				"each Zone requires a Network specification")))
 		})
 	})
 
-	Context("When updating a CloudStackCluster", func() {
-		BeforeEach(func() {
-			Ω(k8sClient.Create(ctx, dummies.CSCluster)).Should(Succeed())
+	ginkgo.Context("When updating a CloudStackCluster", func() {
+		ginkgo.BeforeEach(func() {
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSCluster)).Should(gomega.Succeed())
 		})
 
-		It("Should reject updates to CloudStackCluster FailureDomains", func() {
+		ginkgo.It("Should reject updates to CloudStackCluster FailureDomains", func() {
 			dummies.CSCluster.Spec.FailureDomains[0].Zone.Name = "SomeRandomUpdate"
-			Ω(k8sClient.Update(ctx, dummies.CSCluster)).Should(MatchError(MatchRegexp(forbiddenRegex, "Cannot change FailureDomain")))
+			gomega.Expect(k8sClient.Update(ctx, dummies.CSCluster)).Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "Cannot change FailureDomain")))
 		})
-		It("Should reject updates to Networks specified in CloudStackCluster Zones", func() {
+		ginkgo.It("Should reject updates to Networks specified in CloudStackCluster Zones", func() {
 			dummies.CSCluster.Spec.FailureDomains[0].Zone.Network.Name = "ArbitraryUpdateNetworkName"
-			Ω(k8sClient.Update(ctx, dummies.CSCluster)).Should(MatchError(MatchRegexp(forbiddenRegex, "Cannot change FailureDomain")))
+			gomega.Expect(k8sClient.Update(ctx, dummies.CSCluster)).Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "Cannot change FailureDomain")))
 		})
-		It("Should reject updates to CloudStackCluster controlplaneendpoint.host", func() {
+		ginkgo.It("Should reject updates to CloudStackCluster controlplaneendpoint.host", func() {
 			dummies.CSCluster.Spec.ControlPlaneEndpoint.Host = "1.1.1.1"
-			Ω(k8sClient.Update(ctx, dummies.CSCluster)).
-				Should(MatchError(MatchRegexp(forbiddenRegex, "controlplaneendpoint\\.host")))
+			gomega.Expect(k8sClient.Update(ctx, dummies.CSCluster)).
+				Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "controlplaneendpoint\\.host")))
 		})
 
-		It("Should reject updates to CloudStackCluster controlplaneendpoint.port", func() {
+		ginkgo.It("Should reject updates to CloudStackCluster controlplaneendpoint.port", func() {
 			dummies.CSCluster.Spec.ControlPlaneEndpoint.Port = int32(1234)
-			Ω(k8sClient.Update(ctx, dummies.CSCluster)).
-				Should(MatchError(MatchRegexp(forbiddenRegex, "controlplaneendpoint\\.port")))
+			gomega.Expect(k8sClient.Update(ctx, dummies.CSCluster)).
+				Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "controlplaneendpoint\\.port")))
 		})
 	})
 })

--- a/api/v1beta3/cloudstackmachine_webhook_test.go
+++ b/api/v1beta3/cloudstackmachine_webhook_test.go
@@ -22,89 +22,89 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 )
 
-var _ = Describe("CloudStackMachine webhook", func() {
+var _ = ginkgo.Describe("CloudStackMachine webhook", func() {
 	var ctx context.Context
 	forbiddenRegex := "admission webhook.*denied the request.*Forbidden\\: %s"
 	requiredRegex := "admission webhook.*denied the request.*Required value\\: %s"
 
-	BeforeEach(func() { // Reset test vars to initial state.
+	ginkgo.BeforeEach(func() { // Reset test vars to initial state.
 		dummies.SetDummyVars()
 		ctx = context.Background()
 		_ = k8sClient.Delete(ctx, dummies.CSMachine1) // Clear out any remaining machines. Ignore errors.
 	})
 
-	Context("When creating a CloudStackMachine", func() {
-		It("should accept CloudStackMachine with all attributes", func() {
-			Expect(k8sClient.Create(ctx, dummies.CSMachine1)).Should(Succeed())
+	ginkgo.Context("When creating a CloudStackMachine", func() {
+		ginkgo.It("should accept CloudStackMachine with all attributes", func() {
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSMachine1)).Should(gomega.Succeed())
 		})
 
-		It("should accept a CloudStackMachine with disk Offering attribute", func() {
+		ginkgo.It("should accept a CloudStackMachine with disk Offering attribute", func() {
 			dummies.CSMachine1.Spec.DiskOffering = dummies.DiskOffering
-			Expect(k8sClient.Create(ctx, dummies.CSMachine1)).Should(Succeed())
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSMachine1)).Should(gomega.Succeed())
 		})
 
-		It("should accept a CloudStackMachine with positive disk Offering size attribute", func() {
+		ginkgo.It("should accept a CloudStackMachine with positive disk Offering size attribute", func() {
 			dummies.CSMachine1.Spec.DiskOffering = dummies.DiskOffering
 			dummies.CSMachine1.Spec.DiskOffering.CustomSize = 1
-			Expect(k8sClient.Create(ctx, dummies.CSMachine1)).Should(Succeed())
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSMachine1)).Should(gomega.Succeed())
 		})
 
-		It("should not accept a CloudStackMachine with negative disk Offering size attribute", func() {
+		ginkgo.It("should not accept a CloudStackMachine with negative disk Offering size attribute", func() {
 			dummies.CSMachine1.Spec.DiskOffering = dummies.DiskOffering
 			dummies.CSMachine1.Spec.DiskOffering.CustomSize = -1
-			Expect(k8sClient.Create(ctx, dummies.CSMachine1)).Should(MatchError(MatchRegexp(forbiddenRegex, "customSizeInGB")))
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSMachine1)).Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "customSizeInGB")))
 		})
 
-		It("should reject a CloudStackMachine with missing Offering attribute", func() {
+		ginkgo.It("should reject a CloudStackMachine with missing Offering attribute", func() {
 			dummies.CSMachine1.Spec.Offering = infrav1.CloudStackResourceIdentifier{ID: "", Name: ""}
-			Expect(k8sClient.Create(ctx, dummies.CSMachine1)).
-				Should(MatchError(MatchRegexp(requiredRegex, "Offering")))
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSMachine1)).
+				Should(gomega.MatchError(gomega.MatchRegexp(requiredRegex, "Offering")))
 		})
 
-		It("should reject a CloudStackMachine with missing Template attribute", func() {
+		ginkgo.It("should reject a CloudStackMachine with missing Template attribute", func() {
 			dummies.CSMachine1.Spec.Template = infrav1.CloudStackResourceIdentifier{ID: "", Name: ""}
-			Expect(k8sClient.Create(ctx, dummies.CSMachine1)).
-				Should(MatchError(MatchRegexp(requiredRegex, "Template")))
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSMachine1)).
+				Should(gomega.MatchError(gomega.MatchRegexp(requiredRegex, "Template")))
 		})
 	})
 
-	Context("When updating a CloudStackMachine", func() {
-		BeforeEach(func() {
-			Ω(k8sClient.Create(ctx, dummies.CSMachine1)).Should(Succeed())
+	ginkgo.Context("When updating a CloudStackMachine", func() {
+		ginkgo.BeforeEach(func() {
+			gomega.Ω(k8sClient.Create(ctx, dummies.CSMachine1)).Should(gomega.Succeed())
 		})
 
-		It("should reject VM offering updates to the CloudStackMachine", func() {
+		ginkgo.It("should reject VM offering updates to the CloudStackMachine", func() {
 			dummies.CSMachine1.Spec.Offering = infrav1.CloudStackResourceIdentifier{Name: "ArbitraryUpdateOffering"}
-			Ω(k8sClient.Update(ctx, dummies.CSMachine1)).
-				Should(MatchError(MatchRegexp(forbiddenRegex, "offering")))
+			gomega.Ω(k8sClient.Update(ctx, dummies.CSMachine1)).
+				Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "offering")))
 		})
 
-		It("should reject VM template updates to the CloudStackMachine", func() {
+		ginkgo.It("should reject VM template updates to the CloudStackMachine", func() {
 			dummies.CSMachine1.Spec.Template = infrav1.CloudStackResourceIdentifier{Name: "ArbitraryUpdateTemplate"}
-			Ω(k8sClient.Update(ctx, dummies.CSMachine1)).
-				Should(MatchError(MatchRegexp(forbiddenRegex, "template")))
+			gomega.Ω(k8sClient.Update(ctx, dummies.CSMachine1)).
+				Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "template")))
 		})
 
-		It("should reject VM disk offering updates to the CloudStackMachine", func() {
+		ginkgo.It("should reject VM disk offering updates to the CloudStackMachine", func() {
 			dummies.CSMachine1.Spec.DiskOffering.Name = "medium"
-			Ω(k8sClient.Update(ctx, dummies.CSMachine1)).
-				Should(MatchError(MatchRegexp(forbiddenRegex, "diskOffering")))
+			gomega.Ω(k8sClient.Update(ctx, dummies.CSMachine1)).
+				Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "diskOffering")))
 		})
 
-		It("should reject updates to VM details of the CloudStackMachine", func() {
+		ginkgo.It("should reject updates to VM details of the CloudStackMachine", func() {
 			dummies.CSMachine1.Spec.Details = map[string]string{"memoryOvercommitRatio": "1.5"}
-			Ω(k8sClient.Update(ctx, dummies.CSMachine1)).
-				Should(MatchError(MatchRegexp(forbiddenRegex, "details")))
+			gomega.Ω(k8sClient.Update(ctx, dummies.CSMachine1)).
+				Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "details")))
 		})
 
-		It("should reject updates to the list of affinty groups of the CloudStackMachine", func() {
+		ginkgo.It("should reject updates to the list of affinty groups of the CloudStackMachine", func() {
 			dummies.CSMachine1.Spec.AffinityGroupIDs = []string{"28b907b8-75a7-4214-bd3d-6c61961fc2af"}
-			Ω(k8sClient.Update(ctx, dummies.CSMachine1)).
-				Should(MatchError(MatchRegexp(forbiddenRegex, "AffinityGroupIDs")))
+			gomega.Ω(k8sClient.Update(ctx, dummies.CSMachine1)).
+				Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "AffinityGroupIDs")))
 		})
 	})
 })

--- a/api/v1beta3/cloudstackmachinetemplate_webhook_test.go
+++ b/api/v1beta3/cloudstackmachinetemplate_webhook_test.go
@@ -19,82 +19,81 @@ package v1beta3_test
 import (
 	"context"
 
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("CloudStackMachineTemplate webhook", func() {
+var _ = ginkgo.Describe("CloudStackMachineTemplate webhook", func() {
 	var ctx context.Context
 	forbiddenRegex := "admission webhook.*denied the request.*Forbidden\\: %s"
 	requiredRegex := "admission webhook.*denied the request.*Required value\\: %s"
 
-	BeforeEach(func() { // Reset test vars to initial state.
+	ginkgo.BeforeEach(func() { // Reset test vars to initial state.
 		dummies.SetDummyVars()
 		ctx = context.Background()
 		_ = k8sClient.Delete(ctx, dummies.CSMachineTemplate1) // Delete any remnants.
 	})
 
-	Context("When creating a CloudStackMachineTemplate", func() {
-		It("Should accept a CloudStackMachineTemplate with all attributes present", func() {
-			Expect(k8sClient.Create(ctx, dummies.CSMachineTemplate1)).Should(Succeed())
+	ginkgo.Context("When creating a CloudStackMachineTemplate", func() {
+		ginkgo.It("Should accept a CloudStackMachineTemplate with all attributes present", func() {
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSMachineTemplate1)).Should(gomega.Succeed())
 		})
 
-		It("Should accept a CloudStackMachineTemplate when missing the VM Disk Offering attribute", func() {
+		ginkgo.It("Should accept a CloudStackMachineTemplate when missing the VM Disk Offering attribute", func() {
 			dummies.CSMachineTemplate1.Spec.Template.Spec.DiskOffering = infrav1.CloudStackResourceDiskOffering{
 				CloudStackResourceIdentifier: infrav1.CloudStackResourceIdentifier{Name: "", ID: ""},
 			}
-			Expect(k8sClient.Create(ctx, dummies.CSMachineTemplate1)).Should(Succeed())
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSMachineTemplate1)).Should(gomega.Succeed())
 		})
 
-		It("Should reject a CloudStackMachineTemplate when missing the VM Offering attribute", func() {
+		ginkgo.It("Should reject a CloudStackMachineTemplate when missing the VM Offering attribute", func() {
 			dummies.CSMachineTemplate1.Spec.Template.Spec.Offering = infrav1.CloudStackResourceIdentifier{Name: "", ID: ""}
-			Expect(k8sClient.Create(ctx, dummies.CSMachineTemplate1)).
-				Should(MatchError(MatchRegexp(requiredRegex, "Offering")))
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSMachineTemplate1)).
+				Should(gomega.MatchError(gomega.MatchRegexp(requiredRegex, "Offering")))
 		})
 
-		It("Should reject a CloudStackMachineTemplate when missing the VM Template attribute", func() {
+		ginkgo.It("Should reject a CloudStackMachineTemplate when missing the VM Template attribute", func() {
 			dummies.CSMachineTemplate1.Spec.Template.Spec.Template = infrav1.CloudStackResourceIdentifier{Name: "", ID: ""}
-			Expect(k8sClient.Create(ctx, dummies.CSMachineTemplate1)).
-				Should(MatchError(MatchRegexp(requiredRegex, "Template")))
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSMachineTemplate1)).
+				Should(gomega.MatchError(gomega.MatchRegexp(requiredRegex, "Template")))
 		})
 	})
 
-	Context("When updating a CloudStackMachineTemplate", func() {
-		BeforeEach(func() { // Reset test vars to initial state.
-			Ω(k8sClient.Create(ctx, dummies.CSMachineTemplate1)).Should(Succeed())
+	ginkgo.Context("When updating a CloudStackMachineTemplate", func() {
+		ginkgo.BeforeEach(func() { // Reset test vars to initial state.
+			gomega.Expect(k8sClient.Create(ctx, dummies.CSMachineTemplate1)).Should(gomega.Succeed())
 		})
 
-		It("should reject VM template updates to the CloudStackMachineTemplate", func() {
+		ginkgo.It("should reject VM template updates to the CloudStackMachineTemplate", func() {
 			dummies.CSMachineTemplate1.Spec.Template.Spec.Template = infrav1.CloudStackResourceIdentifier{Name: "ArbitraryUpdateTemplate"}
-			Ω(k8sClient.Update(ctx, dummies.CSMachineTemplate1)).
-				Should(MatchError(MatchRegexp(forbiddenRegex, "template")))
+			gomega.Expect(k8sClient.Update(ctx, dummies.CSMachineTemplate1)).
+				Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "template")))
 		})
 
-		It("should reject VM disk offering updates to the CloudStackMachineTemplate", func() {
+		ginkgo.It("should reject VM disk offering updates to the CloudStackMachineTemplate", func() {
 			dummies.CSMachineTemplate1.Spec.Template.Spec.DiskOffering = infrav1.CloudStackResourceDiskOffering{
 				CloudStackResourceIdentifier: infrav1.CloudStackResourceIdentifier{Name: "DiskOffering2"}}
-			Ω(k8sClient.Update(ctx, dummies.CSMachineTemplate1)).
-				Should(MatchError(MatchRegexp(forbiddenRegex, "diskOffering")))
+			gomega.Expect(k8sClient.Update(ctx, dummies.CSMachineTemplate1)).
+				Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "diskOffering")))
 		})
 
-		It("should reject VM offering updates to the CloudStackMachineTemplate", func() {
+		ginkgo.It("should reject VM offering updates to the CloudStackMachineTemplate", func() {
 			dummies.CSMachineTemplate1.Spec.Template.Spec.Offering = infrav1.CloudStackResourceIdentifier{Name: "Offering2"}
-			Ω(k8sClient.Update(ctx, dummies.CSMachineTemplate1)).
-				Should(MatchError(MatchRegexp(forbiddenRegex, "offering")))
+			gomega.Expect(k8sClient.Update(ctx, dummies.CSMachineTemplate1)).
+				Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "offering")))
 		})
 
-		It("should reject updates to VM details of the CloudStackMachineTemplate", func() {
+		ginkgo.It("should reject updates to VM details of the CloudStackMachineTemplate", func() {
 			dummies.CSMachineTemplate1.Spec.Template.Spec.Details = map[string]string{"memoryOvercommitRatio": "1.5"}
-			Ω(k8sClient.Update(ctx, dummies.CSMachineTemplate1)).
-				Should(MatchError(MatchRegexp(forbiddenRegex, "details")))
+			gomega.Expect(k8sClient.Update(ctx, dummies.CSMachineTemplate1)).
+				Should(gomega.MatchError(gomega.MatchRegexp(forbiddenRegex, "details")))
 		})
 
-		It("should reject updates to the list of AffinityGroupIDs of the CloudStackMachineTemplate", func() {
+		ginkgo.It("should reject updates to the list of AffinityGroupIDs of the CloudStackMachineTemplate", func() {
 			dummies.CSMachineTemplate1.Spec.Template.Spec.AffinityGroupIDs = []string{"28b907b8-75a7-4214-bd3d-6c61961fc2ag"}
-			Ω(k8sClient.Update(ctx, dummies.CSMachineTemplate1)).ShouldNot(Succeed())
+			gomega.Expect(k8sClient.Update(ctx, dummies.CSMachineTemplate1)).ShouldNot(gomega.Succeed())
 		})
 	})
 })

--- a/controllers/cks_cluster_controller_test.go
+++ b/controllers/cks_cluster_controller_test.go
@@ -18,8 +18,8 @@ package controllers_test
 
 import (
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/controllers"
@@ -29,17 +29,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
-var _ = Describe("CksCloudStackClusterReconciler", func() {
-	Context("With k8s like test environment.", func() {
-		BeforeEach(func() {
+var _ = ginkgo.Describe("CksCloudStackClusterReconciler", func() {
+	ginkgo.Context("With k8s like test environment.", func() {
+		ginkgo.BeforeEach(func() {
 			dummies.SetDummyVars()
 			SetupTestEnvironment()
-			Ω(ClusterReconciler.SetupWithManager(ctx, k8sManager, controller.Options{})).Should(Succeed())  // Register CloudStack ClusterReconciler.
-			Ω(FailureDomainReconciler.SetupWithManager(k8sManager, controller.Options{})).Should(Succeed()) // Register CloudStack FailureDomainReconciler.
-			Ω(CksClusterReconciler.SetupWithManager(k8sManager)).Should(Succeed())                          // Register CloudStack Cks ClusterReconciler.
+			gomega.Ω(ClusterReconciler.SetupWithManager(ctx, k8sManager, controller.Options{})).Should(gomega.Succeed())  // Register CloudStack ClusterReconciler.
+			gomega.Ω(FailureDomainReconciler.SetupWithManager(k8sManager, controller.Options{})).Should(gomega.Succeed()) // Register CloudStack FailureDomainReconciler.
+			gomega.Ω(CksClusterReconciler.SetupWithManager(k8sManager)).Should(gomega.Succeed())                          // Register CloudStack Cks ClusterReconciler.
 		})
 
-		It("Should create a cluster in CKS.", func() {
+		ginkgo.It("Should create a cluster in CKS.", func() {
 			mockCloudClient.EXPECT().GetOrCreateCksCluster(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(_, arg1, _ interface{}) {
 				arg1.(*infrav1.CloudStackCluster).Status.CloudStackClusterID = "cluster-id-123"
 			}).MinTimes(1).Return(nil)
@@ -50,47 +50,47 @@ var _ = Describe("CksCloudStackClusterReconciler", func() {
 					arg1.(*infrav1.CloudStackZoneSpec).Network.Type = cloud.NetworkTypeShared
 				}).MinTimes(1)
 
-			Eventually(func() string {
+			gomega.Eventually(func() string {
 				key := client.ObjectKeyFromObject(dummies.CSCluster)
 				if err := k8sClient.Get(ctx, key, dummies.CSCluster); err != nil {
 					return ""
 				}
 				return dummies.CSCluster.Status.CloudStackClusterID
-			}, timeout).WithPolling(pollInterval).Should(Equal("cluster-id-123"))
+			}, timeout).WithPolling(pollInterval).Should(gomega.Equal("cluster-id-123"))
 
 		})
 	})
 
-	Context("With k8s like test environment.", func() {
-		BeforeEach(func() {
+	ginkgo.Context("With k8s like test environment.", func() {
+		ginkgo.BeforeEach(func() {
 			dummies.SetDummyVars()
 			dummies.CSCluster.Status.CloudStackClusterID = "cluster-id-123"
 			SetupTestEnvironment()
-			Ω(ClusterReconciler.SetupWithManager(ctx, k8sManager, controller.Options{})).Should(Succeed())  // Register CloudStack ClusterReconciler.
-			Ω(FailureDomainReconciler.SetupWithManager(k8sManager, controller.Options{})).Should(Succeed()) // Register CloudStack FailureDomainReconciler.
-			Ω(CksClusterReconciler.SetupWithManager(k8sManager)).Should(Succeed())                          // Register CloudStack Cks ClusterReconciler.
+			gomega.Ω(ClusterReconciler.SetupWithManager(ctx, k8sManager, controller.Options{})).Should(gomega.Succeed())  // Register CloudStack ClusterReconciler.
+			gomega.Ω(FailureDomainReconciler.SetupWithManager(k8sManager, controller.Options{})).Should(gomega.Succeed()) // Register CloudStack FailureDomainReconciler.
+			gomega.Ω(CksClusterReconciler.SetupWithManager(k8sManager)).Should(gomega.Succeed())                          // Register CloudStack Cks ClusterReconciler.
 		})
 
-		It("Should delete the cluster in CKS.", func() {
+		ginkgo.It("Should delete the cluster in CKS.", func() {
 
-			Ω(k8sClient.Delete(ctx, dummies.CSCluster)).Should(Succeed())
+			gomega.Ω(k8sClient.Delete(ctx, dummies.CSCluster)).Should(gomega.Succeed())
 
-			Eventually(func() bool {
+			gomega.Eventually(func() bool {
 				csCluster := &infrav1.CloudStackCluster{}
 				csClusterKey := client.ObjectKey{Namespace: dummies.ClusterNameSpace, Name: dummies.CSCluster.Name}
 				if err := k8sClient.Get(ctx, csClusterKey, csCluster); err != nil {
 					return errors.IsNotFound(err)
 				}
 				return false
-			}, timeout).WithPolling(pollInterval).Should(BeTrue())
+			}, timeout).WithPolling(pollInterval).Should(gomega.BeTrue())
 		})
 
 	})
 
-	Context("Without a k8s test environment.", func() {
-		It("Should create a reconciliation runner with a Cloudstack Cluster as the reconciliation subject.", func() {
+	ginkgo.Context("Without a k8s test environment.", func() {
+		ginkgo.It("Should create a reconciliation runner with a Cloudstack Cluster as the reconciliation subject.", func() {
 			reconRunner := controllers.NewCksClusterReconciliationRunner()
-			Ω(reconRunner.ReconciliationSubject).ShouldNot(BeNil())
+			gomega.Ω(reconRunner.ReconciliationSubject).ShouldNot(gomega.BeNil())
 		})
 	})
 })

--- a/controllers/cloudstackcluster_controller_test.go
+++ b/controllers/cloudstackcluster_controller_test.go
@@ -18,8 +18,8 @@ package controllers_test
 
 import (
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/controllers"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
@@ -27,32 +27,32 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
-var _ = Describe("CloudStackClusterReconciler", func() {
-	Context("With k8s like test environment.", func() {
-		BeforeEach(func() {
-			SetupTestEnvironment()                                                                          // Must happen before setting up managers/reconcilers.
-			Ω(ClusterReconciler.SetupWithManager(ctx, k8sManager, controller.Options{})).Should(Succeed())  // Register CloudStack ClusterReconciler.
-			Ω(FailureDomainReconciler.SetupWithManager(k8sManager, controller.Options{})).Should(Succeed()) // Register CloudStack FailureDomainReconciler.
+var _ = ginkgo.Describe("CloudStackClusterReconciler", func() {
+	ginkgo.Context("With k8s like test environment.", func() {
+		ginkgo.BeforeEach(func() {
+			SetupTestEnvironment()                                                                                        // Must happen before setting up managers/reconcilers.
+			gomega.Ω(ClusterReconciler.SetupWithManager(ctx, k8sManager, controller.Options{})).Should(gomega.Succeed())  // Register CloudStack ClusterReconciler.
+			gomega.Ω(FailureDomainReconciler.SetupWithManager(k8sManager, controller.Options{})).Should(gomega.Succeed()) // Register CloudStack FailureDomainReconciler.
 		})
 
-		It("Should create a CloudStackFailureDomain.", func() {
+		ginkgo.It("Should create a CloudStackFailureDomain.", func() {
 			tempfd := &infrav1.CloudStackFailureDomain{}
 			mockCloudClient.EXPECT().ResolveZone(gomock.Any()).AnyTimes()
-			Eventually(func() bool {
+			gomega.Eventually(func() bool {
 				key := client.ObjectKeyFromObject(dummies.CSFailureDomain1)
 				key.Name = key.Name + "-" + dummies.CSCluster.Name
 				if err := k8sClient.Get(ctx, key, tempfd); err != nil {
 					return true
 				}
 				return false
-			}, timeout).WithPolling(pollInterval).Should(BeTrue())
+			}, timeout).WithPolling(pollInterval).Should(gomega.BeTrue())
 		})
 	})
 
-	Context("Without a k8s test environment.", func() {
-		It("Should create a reconciliation runner with a Cloudstack Cluster as the reconciliation subject.", func() {
+	ginkgo.Context("Without a k8s test environment.", func() {
+		ginkgo.It("Should create a reconciliation runner with a Cloudstack Cluster as the reconciliation subject.", func() {
 			reconRunenr := controllers.NewCSClusterReconciliationRunner()
-			Ω(reconRunenr.ReconciliationSubject).ShouldNot(BeNil())
+			gomega.Ω(reconRunenr.ReconciliationSubject).ShouldNot(gomega.BeNil())
 		})
 	})
 })

--- a/controllers/cloudstackfailuredomain_controller_test.go
+++ b/controllers/cloudstackfailuredomain_controller_test.go
@@ -18,8 +18,8 @@ package controllers_test
 
 import (
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
@@ -31,17 +31,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
-var _ = Describe("CloudStackFailureDomainReconciler", func() {
-	Context("With k8s like test environment.", func() {
-		BeforeEach(func() {
+var _ = ginkgo.Describe("CloudStackFailureDomainReconciler", func() {
+	ginkgo.Context("With k8s like test environment.", func() {
+		ginkgo.BeforeEach(func() {
 			dummies.SetDummyVars()
-			SetupTestEnvironment()                                                                          // Must happen before setting up managers/reconcilers.
-			Ω(FailureDomainReconciler.SetupWithManager(k8sManager, controller.Options{})).Should(Succeed()) // Register CloudStack FailureDomainReconciler.
+			SetupTestEnvironment()                                                                                        // Must happen before setting up managers/reconcilers.
+			gomega.Ω(FailureDomainReconciler.SetupWithManager(k8sManager, controller.Options{})).Should(gomega.Succeed()) // Register CloudStack FailureDomainReconciler.
 			// Modify failure domain name the same way the cluster controller would.
 			dummies.CSFailureDomain1.Name = dummies.CSFailureDomain1.Name + "-" + dummies.CSCluster.Name
 
-			Ω(k8sClient.Create(ctx, dummies.ACSEndpointSecret1))
-			Ω(k8sClient.Create(ctx, dummies.CSFailureDomain1))
+			gomega.Ω(k8sClient.Create(ctx, dummies.ACSEndpointSecret1))
+			gomega.Ω(k8sClient.Create(ctx, dummies.CSFailureDomain1))
 
 			mockCloudClient.EXPECT().ResolveZone(gomock.Any()).MinTimes(1)
 
@@ -52,28 +52,28 @@ var _ = Describe("CloudStackFailureDomainReconciler", func() {
 				}).MinTimes(1)
 		})
 
-		It("Should delete failure domain if no VM under this failure domain.", func() {
-			Eventually(func() bool {
+		ginkgo.It("Should delete failure domain if no VM under this failure domain.", func() {
+			gomega.Eventually(func() bool {
 				return getFailuredomainStatus(dummies.CSFailureDomain1)
-			}, timeout).WithPolling(pollInterval).Should(BeTrue())
+			}, timeout).WithPolling(pollInterval).Should(gomega.BeTrue())
 
-			Ω(k8sClient.Delete(ctx, dummies.CSFailureDomain1))
+			gomega.Ω(k8sClient.Delete(ctx, dummies.CSFailureDomain1))
 
 			tempfd := &infrav1.CloudStackFailureDomain{}
-			Eventually(func() bool {
+			gomega.Eventually(func() bool {
 				key := client.ObjectKeyFromObject(dummies.CSFailureDomain1)
 				if err := k8sClient.Get(ctx, key, tempfd); err != nil {
 					return errors.IsNotFound(err)
 				}
 				return false
-			}, timeout).WithPolling(pollInterval).Should(BeTrue())
+			}, timeout).WithPolling(pollInterval).Should(gomega.BeTrue())
 		})
 
-		DescribeTable("Should function in different replicas conditions",
+		ginkgo.DescribeTable("Should function in different replicas conditions",
 			func(shouldDeleteVM bool, specReplicas, statusReplicas, statusReadyReplicas *int32, statusReady *bool, controlPlaneReady bool) {
-				Eventually(func() bool {
+				gomega.Eventually(func() bool {
 					return getFailuredomainStatus(dummies.CSFailureDomain1)
-				}, timeout).WithPolling(pollInterval).Should(BeTrue())
+				}, timeout).WithPolling(pollInterval).Should(gomega.BeTrue())
 
 				setCSMachineOwnerCRD(dummies.CSMachineOwner, specReplicas, statusReplicas, statusReadyReplicas, statusReady)
 				setCAPIMachineAndCSMachineCRDs(dummies.CSMachine1, dummies.CAPIMachine)
@@ -81,9 +81,9 @@ var _ = Describe("CloudStackFailureDomainReconciler", func() {
 				labelMachineFailuredomain(dummies.CSMachine1, dummies.CSFailureDomain1)
 
 				if !controlPlaneReady {
-					Eventually(func() error {
+					gomega.Eventually(func() error {
 						ph, err := patch.NewHelper(dummies.CAPICluster, k8sClient)
-						Ω(err).ShouldNot(HaveOccurred())
+						gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
 						dummies.CAPICluster.Status.Conditions = []clusterv1.Condition{
 							{
 								Type:   "Ready",
@@ -91,43 +91,43 @@ var _ = Describe("CloudStackFailureDomainReconciler", func() {
 							},
 						}
 						return ph.Patch(ctx, dummies.CAPICluster, patch.WithStatusObservedGeneration{})
-					}, timeout).Should(Succeed())
+					}, timeout).Should(gomega.Succeed())
 				}
 
-				Ω(k8sClient.Delete(ctx, dummies.CSFailureDomain1))
+				gomega.Ω(k8sClient.Delete(ctx, dummies.CSFailureDomain1))
 
 				CAPIMachine := &clusterv1.Machine{}
 				if shouldDeleteVM {
-					Eventually(func() bool {
+					gomega.Eventually(func() bool {
 						key := client.ObjectKey{Namespace: dummies.ClusterNameSpace, Name: dummies.CAPIMachine.Name}
 						if err := k8sClient.Get(ctx, key, CAPIMachine); err != nil {
 							return errors.IsNotFound(err)
 						}
 						return false
-					}, timeout).WithPolling(pollInterval).Should(BeTrue())
+					}, timeout).WithPolling(pollInterval).Should(gomega.BeTrue())
 				} else {
-					Consistently(func() bool {
+					gomega.Consistently(func() bool {
 						key := client.ObjectKey{Namespace: dummies.ClusterNameSpace, Name: dummies.CAPIMachine.Name}
 						if err := k8sClient.Get(ctx, key, CAPIMachine); err == nil {
 							return CAPIMachine.DeletionTimestamp.IsZero()
 						}
 						return false
-					}, timeout).WithPolling(pollInterval).Should(BeTrue())
+					}, timeout).WithPolling(pollInterval).Should(gomega.BeTrue())
 				}
 
 			},
 			// should delete - simulate owner is kubeadmcontrolplane
-			Entry("Should delete machine if spec.replicas > 1", true, pointer.Int32(2), pointer.Int32(2), pointer.Int32(2), pointer.Bool(true), true),
+			ginkgo.Entry("Should delete machine if spec.replicas > 1", true, pointer.Int32(2), pointer.Int32(2), pointer.Int32(2), pointer.Bool(true), true),
 			// should delete - simulate owner is etcdadmcluster
-			Entry("Should delete machine if status.readyReplica does not exist", true, pointer.Int32(2), pointer.Int32(2), nil, pointer.Bool(true), true),
+			ginkgo.Entry("Should delete machine if status.readyReplica does not exist", true, pointer.Int32(2), pointer.Int32(2), nil, pointer.Bool(true), true),
 			// should delete - simulate owner is machineset
-			Entry("Should delete machine if status.ready does not exist", true, pointer.Int32(2), pointer.Int32(2), pointer.Int32(2), nil, true),
+			ginkgo.Entry("Should delete machine if status.ready does not exist", true, pointer.Int32(2), pointer.Int32(2), pointer.Int32(2), nil, true),
 			// should not delete if condition not met
-			Entry("Should not delete machine if cluster control plane not ready", false, pointer.Int32(2), pointer.Int32(2), pointer.Int32(2), pointer.Bool(true), false),
-			Entry("Should not delete machine if status.replicas < spec.replicas", false, pointer.Int32(2), pointer.Int32(1), pointer.Int32(1), pointer.Bool(true), true),
-			Entry("Should not delete machine if spec.replicas < 2", false, pointer.Int32(1), pointer.Int32(1), pointer.Int32(1), pointer.Bool(true), true),
-			Entry("Should not delete machine if status.ready is false", false, pointer.Int32(2), pointer.Int32(2), pointer.Int32(2), pointer.Bool(false), true),
-			Entry("Should not delete machine if status.readyReplicas <> status.replicas", false, pointer.Int32(2), pointer.Int32(2), pointer.Int32(1), pointer.Bool(true), true),
+			ginkgo.Entry("Should not delete machine if cluster control plane not ready", false, pointer.Int32(2), pointer.Int32(2), pointer.Int32(2), pointer.Bool(true), false),
+			ginkgo.Entry("Should not delete machine if status.replicas < spec.replicas", false, pointer.Int32(2), pointer.Int32(1), pointer.Int32(1), pointer.Bool(true), true),
+			ginkgo.Entry("Should not delete machine if spec.replicas < 2", false, pointer.Int32(1), pointer.Int32(1), pointer.Int32(1), pointer.Bool(true), true),
+			ginkgo.Entry("Should not delete machine if status.ready is false", false, pointer.Int32(2), pointer.Int32(2), pointer.Int32(2), pointer.Bool(false), true),
+			ginkgo.Entry("Should not delete machine if status.readyReplicas <> status.replicas", false, pointer.Int32(2), pointer.Int32(2), pointer.Int32(1), pointer.Bool(true), true),
 		)
 	})
 })

--- a/controllers/cloudstackisolatednetwork_controller.go
+++ b/controllers/cloudstackisolatednetwork_controller.go
@@ -95,7 +95,7 @@ func (r *CloudStackIsoNetReconciliationRunner) Reconcile() (retRes ctrl.Result, 
 
 func (r *CloudStackIsoNetReconciliationRunner) ReconcileDelete() (retRes ctrl.Result, retErr error) {
 	r.Log.Info("Deleting IsolatedNetwork.")
-	if err := r.CSUser.DisposeIsoNetResources(r.FailureDomain, r.ReconciliationSubject, r.CSCluster); err != nil {
+	if err := r.CSUser.DisposeIsoNetResources(r.ReconciliationSubject, r.CSCluster); err != nil {
 		if !strings.Contains(strings.ToLower(err.Error()), "no match found") {
 			return ctrl.Result{}, err
 		}

--- a/controllers/cloudstackisolatednetwork_controller_test.go
+++ b/controllers/cloudstackisolatednetwork_controller_test.go
@@ -18,8 +18,8 @@ package controllers_test
 
 import (
 	g "github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
@@ -27,24 +27,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("CloudStackIsolatedNetworkReconciler", func() {
-	Context("With k8s like test environment.", func() {
-		BeforeEach(func() {
+var _ = ginkgo.Describe("CloudStackIsolatedNetworkReconciler", func() {
+	ginkgo.Context("With k8s like test environment.", func() {
+		ginkgo.BeforeEach(func() {
 			SetupTestEnvironment() // Must happen before setting up managers/reconcilers.
 			dummies.SetDummyVars()
-			Ω(IsoNetReconciler.SetupWithManager(k8sManager)).Should(Succeed()) // Register CloudStack IsoNetReconciler.
+			gomega.Ω(IsoNetReconciler.SetupWithManager(k8sManager)).Should(gomega.Succeed()) // Register CloudStack IsoNetReconciler.
 		})
 
-		It("Should set itself to ready if there are no errors in calls to CloudStack methods.", func() {
+		ginkgo.It("Should set itself to ready if there are no errors in calls to CloudStack methods.", func() {
 			mockCloudClient.EXPECT().GetOrCreateIsolatedNetwork(g.Any(), g.Any(), g.Any()).AnyTimes()
 			mockCloudClient.EXPECT().AddClusterTag(g.Any(), g.Any(), g.Any()).AnyTimes()
 
 			// We use CSFailureDomain2 here because CSFailureDomain1 has an empty Spec.Zone.ID
 			dummies.CSISONet1.Spec.FailureDomainName = dummies.CSFailureDomain2.Spec.Name
-			Ω(k8sClient.Create(ctx, dummies.CSFailureDomain2)).Should(Succeed())
-			Ω(k8sClient.Create(ctx, dummies.CSISONet1)).Should(Succeed())
+			gomega.Ω(k8sClient.Create(ctx, dummies.CSFailureDomain2)).Should(gomega.Succeed())
+			gomega.Ω(k8sClient.Create(ctx, dummies.CSISONet1)).Should(gomega.Succeed())
 
-			Eventually(func() bool {
+			gomega.Eventually(func() bool {
 				tempIsoNet := &infrav1.CloudStackIsolatedNetwork{}
 				key := client.ObjectKeyFromObject(dummies.CSISONet1)
 				if err := k8sClient.Get(ctx, key, tempIsoNet); err == nil {
@@ -53,25 +53,25 @@ var _ = Describe("CloudStackIsolatedNetworkReconciler", func() {
 					}
 				}
 				return false
-			}, timeout).WithPolling(pollInterval).Should(BeTrue())
+			}, timeout).WithPolling(pollInterval).Should(gomega.BeTrue())
 		})
 	})
 
-	Context("With a fake ctrlRuntimeClient and no test Env at all.", func() {
-		BeforeEach(func() {
+	ginkgo.Context("With a fake ctrlRuntimeClient and no test Env at all.", func() {
+		ginkgo.BeforeEach(func() {
 			setupFakeTestClient()
 		})
 
-		It("Should requeue in case the zone ID is not resolved yet.", func() {
+		ginkgo.It("Should requeue in case the zone ID is not resolved yet.", func() {
 			// We use CSFailureDomain1 here because it has an empty Spec.Zone.ID
 			dummies.CSISONet1.Spec.FailureDomainName = dummies.CSFailureDomain1.Spec.Name
-			Ω(fakeCtrlClient.Create(ctx, dummies.CSFailureDomain1)).Should(Succeed())
-			Ω(fakeCtrlClient.Create(ctx, dummies.CSISONet1)).Should(Succeed())
+			gomega.Ω(fakeCtrlClient.Create(ctx, dummies.CSFailureDomain1)).Should(gomega.Succeed())
+			gomega.Ω(fakeCtrlClient.Create(ctx, dummies.CSISONet1)).Should(gomega.Succeed())
 
 			requestNamespacedName := types.NamespacedName{Namespace: dummies.ClusterNameSpace, Name: dummies.CSISONet1.Name}
 			res, err := IsoNetReconciler.Reconcile(ctx, ctrl.Request{NamespacedName: requestNamespacedName})
-			Ω(err).ShouldNot(HaveOccurred())
-			Ω(res.RequeueAfter).ShouldNot(BeZero())
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Ω(res.RequeueAfter).ShouldNot(gomega.BeZero())
 		})
 	})
 })

--- a/controllers/utils/base_reconciler.go
+++ b/controllers/utils/base_reconciler.go
@@ -231,7 +231,8 @@ func (r *ReconciliationRunner) CheckOwnedCRDsForReadiness(gvks ...schema.GroupVe
 				if ready, found, err := unstructured.NestedBool(owned.Object, "status", "ready"); err != nil {
 					return ctrl.Result{}, errors.Wrapf(err, "parsing ready for object %s", owned)
 				} else if !found || !ready {
-					if name, found, err := unstructured.NestedString(owned.Object, "metadata", "name"); err != nil {
+					name, found, err := unstructured.NestedString(owned.Object, "metadata", "name")
+					if err != nil {
 						return ctrl.Result{}, errors.Wrapf(err, "parsing name for object %s", owned)
 					} else if !found {
 						return r.RequeueWithMessage(
@@ -239,10 +240,9 @@ func (r *ReconciliationRunner) CheckOwnedCRDsForReadiness(gvks ...schema.GroupVe
 								"Owned object of kind %s with name %s not found, requeuing.",
 								gvk.Kind,
 								owned.GetName()))
-					} else {
-						r.Log.Info(fmt.Sprintf("Owned object %s of kind %s not ready, requeuing", name, gvk.Kind))
-						return ctrl.Result{RequeueAfter: RequeueTimeout}, nil
 					}
+					r.Log.Info(fmt.Sprintf("Owned object %s of kind %s not ready, requeuing", name, gvk.Kind))
+					return ctrl.Result{RequeueAfter: RequeueTimeout}, nil
 				}
 			}
 		}

--- a/pkg/cloud/affinity_groups.go
+++ b/pkg/cloud/affinity_groups.go
@@ -51,11 +51,10 @@ func (c *client) FetchAffinityGroup(group *AffinityGroup) (reterr error) {
 		} else if count > 1 {
 			// handle via creating a new error.
 			return errors.New("count bad")
-		} else {
-			group.Name = affinityGroup.Name
-			group.Type = affinityGroup.Type
-			return nil
 		}
+		group.Name = affinityGroup.Name
+		group.Type = affinityGroup.Type
+		return nil
 	}
 	if group.Name != "" {
 		affinityGroup, count, err := c.cs.AffinityGroup.GetAffinityGroupByName(group.Name, cloudstack.WithProject(c.user.Project.ID))
@@ -66,11 +65,10 @@ func (c *client) FetchAffinityGroup(group *AffinityGroup) (reterr error) {
 		} else if count > 1 {
 			// handle via creating a new error.
 			return errors.New("count bad")
-		} else {
-			group.ID = affinityGroup.Id
-			group.Type = affinityGroup.Type
-			return nil
 		}
+		group.ID = affinityGroup.Id
+		group.Type = affinityGroup.Type
+		return nil
 	}
 	return errors.Errorf(`could not fetch AffinityGroup by name "%s" or id "%s"`, group.Name, group.ID)
 }
@@ -104,18 +102,18 @@ type affinityGroups []AffinityGroup
 
 func (c *client) getCurrentAffinityGroups(csMachine *infrav1.CloudStackMachine) (affinityGroups, error) {
 	// Start by fetching VM details which includes an array of currently associated affinity groups.
-	if virtM, count, err := c.cs.VirtualMachine.GetVirtualMachineByID(*csMachine.Spec.InstanceID, cloudstack.WithProject(c.user.Project.ID)); err != nil {
+	virtM, count, err := c.cs.VirtualMachine.GetVirtualMachineByID(*csMachine.Spec.InstanceID, cloudstack.WithProject(c.user.Project.ID))
+	if err != nil {
 		c.customMetrics.EvaluateErrorAndIncrementAcsReconciliationErrorCounter(err)
 		return nil, err
 	} else if count > 1 {
 		return nil, errors.Errorf("found more than one VM for ID: %s", *csMachine.Spec.InstanceID)
-	} else {
-		groups := make([]AffinityGroup, 0, len(virtM.Affinitygroup))
-		for _, v := range virtM.Affinitygroup {
-			groups = append(groups, AffinityGroup{Name: v.Name, Type: v.Type, ID: v.Id})
-		}
-		return groups, nil
 	}
+	groups := make([]AffinityGroup, 0, len(virtM.Affinitygroup))
+	for _, v := range virtM.Affinitygroup {
+		groups = append(groups, AffinityGroup{Name: v.Name, Type: v.Type, ID: v.Id})
+	}
+	return groups, nil
 }
 
 func (ags *affinityGroups) toArrayOfIDs() []string {

--- a/pkg/cloud/affinity_groups_test.go
+++ b/pkg/cloud/affinity_groups_test.go
@@ -21,13 +21,13 @@ import (
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
 )
 
-var _ = Describe("AffinityGroup Unit Tests", func() {
+var _ = ginkgo.Describe("AffinityGroup Unit Tests", func() {
 	const (
 		errorMessage = "Fake Error"
 	)
@@ -41,9 +41,9 @@ var _ = Describe("AffinityGroup Unit Tests", func() {
 		client     cloud.Client
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		// Setup new mock services.
-		mockCtrl = gomock.NewController(GinkgoT())
+		mockCtrl = gomock.NewController(ginkgo.GinkgoT())
 		mockClient = cloudstack.NewMockClient(mockCtrl)
 		ags = mockClient.AffinityGroup.(*cloudstack.MockAffinityGroupServiceIface)
 		vms = mockClient.VirtualMachine.(*cloudstack.MockVirtualMachineServiceIface)
@@ -51,117 +51,117 @@ var _ = Describe("AffinityGroup Unit Tests", func() {
 		dummies.SetDummyVars()
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 		mockCtrl.Finish()
 	})
 
-	Context("Fetch or Create Affinity group", func() {
-		It("fetches an affinity group by Name", func() {
+	ginkgo.Context("Fetch or Create Affinity group", func() {
+		ginkgo.It("fetches an affinity group by Name", func() {
 			dummies.AffinityGroup.ID = "" // Force name fetching.
 			ags.EXPECT().GetAffinityGroupByName(dummies.AffinityGroup.Name, gomock.Any()).Return(&cloudstack.AffinityGroup{}, 1, nil)
 
-			Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(Succeed())
+			gomega.Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(gomega.Succeed())
 		})
 
-		It("fetches an affinity group by ID", func() {
+		ginkgo.It("fetches an affinity group by ID", func() {
 			ags.EXPECT().GetAffinityGroupByID(dummies.AffinityGroup.ID, gomock.Any()).Return(&cloudstack.AffinityGroup{}, 1, nil)
 
-			Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(Succeed())
+			gomega.Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(gomega.Succeed())
 		})
 
-		It("creates an affinity group", func() {
+		ginkgo.It("creates an affinity group", func() {
 			// dummies.SetDummyDomainAndAccount()
 			// dummies.SetDummyDomainID()
 			ags.EXPECT().GetAffinityGroupByID(dummies.AffinityGroup.ID, gomock.Any()).Return(nil, -1, fakeError)
 			ags.EXPECT().NewCreateAffinityGroupParams(dummies.AffinityGroup.Name, dummies.AffinityGroup.Type).
 				Return(&cloudstack.CreateAffinityGroupParams{})
-			ags.EXPECT().CreateAffinityGroup(ParamMatch(And(NameEquals(dummies.AffinityGroup.Name)))).
+			ags.EXPECT().CreateAffinityGroup(ParamMatch(gomega.And(NameEquals(dummies.AffinityGroup.Name)))).
 				Return(&cloudstack.CreateAffinityGroupResponse{}, nil)
 
-			Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(Succeed())
+			gomega.Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(gomega.Succeed())
 		})
 
-		It("creates an affinity group if Name provided returns more than one affinity group", func() {
+		ginkgo.It("creates an affinity group if Name provided returns more than one affinity group", func() {
 			dummies.AffinityGroup.ID = "" // Force name fetching.
 			agp := &cloudstack.CreateAffinityGroupParams{}
 			ags.EXPECT().GetAffinityGroupByName(dummies.AffinityGroup.Name, gomock.Any()).Return(&cloudstack.AffinityGroup{}, 2, nil)
 			ags.EXPECT().NewCreateAffinityGroupParams(gomock.Any(), gomock.Any()).Return(agp)
 			ags.EXPECT().CreateAffinityGroup(agp).Return(&cloudstack.CreateAffinityGroupResponse{}, nil)
 
-			Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(Succeed())
+			gomega.Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(gomega.Succeed())
 		})
 
-		It("creates an affinity group if getting affinity group by name fails", func() {
+		ginkgo.It("creates an affinity group if getting affinity group by name fails", func() {
 			dummies.AffinityGroup.ID = "" // Force name fetching.
 			agp := &cloudstack.CreateAffinityGroupParams{}
 			ags.EXPECT().GetAffinityGroupByName(dummies.AffinityGroup.Name, gomock.Any()).Return(nil, -1, fakeError)
 			ags.EXPECT().NewCreateAffinityGroupParams(gomock.Any(), gomock.Any()).Return(agp)
 			ags.EXPECT().CreateAffinityGroup(agp).Return(&cloudstack.CreateAffinityGroupResponse{}, nil)
 
-			Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(Succeed())
+			gomega.Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(gomega.Succeed())
 		})
 
-		It("creates an affinity group if ID provided returns more than one affinity group", func() {
+		ginkgo.It("creates an affinity group if ID provided returns more than one affinity group", func() {
 			agp := &cloudstack.CreateAffinityGroupParams{}
 			ags.EXPECT().GetAffinityGroupByID(dummies.AffinityGroup.ID, gomock.Any()).Return(&cloudstack.AffinityGroup{}, 2, nil)
 			ags.EXPECT().NewCreateAffinityGroupParams(gomock.Any(), gomock.Any()).Return(agp)
 			ags.EXPECT().CreateAffinityGroup(agp).Return(&cloudstack.CreateAffinityGroupResponse{}, nil)
 
-			Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(Succeed())
+			gomega.Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(gomega.Succeed())
 		})
 
-		It("creates an affinity group if getting affinity group by ID fails", func() {
+		ginkgo.It("creates an affinity group if getting affinity group by ID fails", func() {
 			agp := &cloudstack.CreateAffinityGroupParams{}
 			ags.EXPECT().GetAffinityGroupByID(dummies.AffinityGroup.ID, gomock.Any()).Return(nil, -1, fakeError)
 			ags.EXPECT().NewCreateAffinityGroupParams(gomock.Any(), gomock.Any()).Return(agp)
 			ags.EXPECT().CreateAffinityGroup(agp).Return(&cloudstack.CreateAffinityGroupResponse{}, nil)
 
-			Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(Succeed())
+			gomega.Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(gomega.Succeed())
 		})
 	})
 
-	Context("Delete Affinity group in CloudStack", func() {
-		It("delete affinity group", func() {
+	ginkgo.Context("Delete Affinity group in CloudStack", func() {
+		ginkgo.It("delete affinity group", func() {
 			agp := &cloudstack.DeleteAffinityGroupParams{}
 			ags.EXPECT().NewDeleteAffinityGroupParams().Return(agp)
 			ags.EXPECT().DeleteAffinityGroup(agp).Return(&cloudstack.DeleteAffinityGroupResponse{}, nil)
 
-			Ω(client.DeleteAffinityGroup(dummies.AffinityGroup)).Should(Succeed())
+			gomega.Ω(client.DeleteAffinityGroup(dummies.AffinityGroup)).Should(gomega.Succeed())
 		})
 	})
 
-	Context("AffinityGroup Integ Tests", Label("integ"), func() {
+	ginkgo.Context("AffinityGroup Integ Tests", ginkgo.Label("integ"), func() {
 
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			client = realCloudClient
 			dummies.AffinityGroup.ID = "" // Force name fetching.
 		})
 
-		It("Associates an affinity group.", func() {
-			Ω(client.ResolveZone(&dummies.CSFailureDomain1.Spec.Zone)).Should(Succeed())
+		ginkgo.It("Associates an affinity group.", func() {
+			gomega.Ω(client.ResolveZone(&dummies.CSFailureDomain1.Spec.Zone)).Should(gomega.Succeed())
 			dummies.CSMachine1.Spec.DiskOffering.Name = ""
 
-			Ω(client.GetOrCreateVMInstance(
+			gomega.Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "",
-			)).Should(Succeed())
+			)).Should(gomega.Succeed())
 
-			Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(Succeed())
-			Ω(client.AssociateAffinityGroup(dummies.CSMachine1, *dummies.AffinityGroup)).Should(Succeed())
+			gomega.Ω(client.GetOrCreateAffinityGroup(dummies.AffinityGroup)).Should(gomega.Succeed())
+			gomega.Ω(client.AssociateAffinityGroup(dummies.CSMachine1, *dummies.AffinityGroup)).Should(gomega.Succeed())
 
 			// Make the created VM go away quickly by force stopping it.
 			p := realCSClient.VirtualMachine.NewStopVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID)
 			p.SetForced(true)
 			_, err := realCSClient.VirtualMachine.StopVirtualMachine(p)
-			Ω(err).ShouldNot(HaveOccurred())
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
 		})
 
-		It("Creates and deletes an affinity group.", func() {
-			Ω(client.DeleteAffinityGroup(dummies.AffinityGroup)).Should(Succeed())
-			Ω(client.FetchAffinityGroup(dummies.AffinityGroup)).ShouldNot(Succeed())
+		ginkgo.It("Creates and deletes an affinity group.", func() {
+			gomega.Ω(client.DeleteAffinityGroup(dummies.AffinityGroup)).Should(gomega.Succeed())
+			gomega.Ω(client.FetchAffinityGroup(dummies.AffinityGroup)).ShouldNot(gomega.Succeed())
 		})
 	})
 
-	It("Associate affinity group", func() {
+	ginkgo.It("Associate affinity group", func() {
 		uagp := &cloudstack.UpdateVMAffinityGroupParams{}
 		vmp := &cloudstack.StartVirtualMachineParams{}
 		vms.EXPECT().GetVirtualMachineByID(*dummies.CSMachine1.Spec.InstanceID, gomock.Any()).Return(&cloudstack.VirtualMachine{}, 1, nil)
@@ -171,10 +171,10 @@ var _ = Describe("AffinityGroup Unit Tests", func() {
 		ags.EXPECT().UpdateVMAffinityGroup(uagp).Return(&cloudstack.UpdateVMAffinityGroupResponse{}, nil)
 		vms.EXPECT().NewStartVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).Return(vmp)
 		vms.EXPECT().StartVirtualMachine(vmp).Return(&cloudstack.StartVirtualMachineResponse{}, nil)
-		Ω(client.AssociateAffinityGroup(dummies.CSMachine1, *dummies.AffinityGroup)).Should(Succeed())
+		gomega.Ω(client.AssociateAffinityGroup(dummies.CSMachine1, *dummies.AffinityGroup)).Should(gomega.Succeed())
 	})
 
-	It("Disassociate affinity group", func() {
+	ginkgo.It("Disassociate affinity group", func() {
 		uagp := &cloudstack.UpdateVMAffinityGroupParams{}
 		vmp := &cloudstack.StartVirtualMachineParams{}
 		vms.EXPECT().GetVirtualMachineByID(*dummies.CSMachine1.Spec.InstanceID, gomock.Any()).Return(&cloudstack.VirtualMachine{}, 1, nil)
@@ -184,6 +184,6 @@ var _ = Describe("AffinityGroup Unit Tests", func() {
 		ags.EXPECT().UpdateVMAffinityGroup(uagp).Return(&cloudstack.UpdateVMAffinityGroupResponse{}, nil)
 		vms.EXPECT().NewStartVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).Return(vmp)
 		vms.EXPECT().StartVirtualMachine(vmp).Return(&cloudstack.StartVirtualMachineResponse{}, nil)
-		Ω(client.DisassociateAffinityGroup(dummies.CSMachine1, *dummies.AffinityGroup)).Should(Succeed())
+		gomega.Ω(client.DisassociateAffinityGroup(dummies.CSMachine1, *dummies.AffinityGroup)).Should(gomega.Succeed())
 	})
 })

--- a/pkg/cloud/cks_cluster.go
+++ b/pkg/cloud/cks_cluster.go
@@ -38,7 +38,7 @@ type ClustertypeSetter interface {
 }
 
 func withExternalManaged() cloudstack.OptionFunc {
-	return func(cs *cloudstack.CloudStackClient, p interface{}) error {
+	return func(_ *cloudstack.CloudStackClient, p interface{}) error {
 		ps, ok := p.(ClustertypeSetter)
 		if !ok {
 			return errors.New("invalid params type")

--- a/pkg/cloud/client_test.go
+++ b/pkg/cloud/client_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/test/helpers"
@@ -37,7 +37,7 @@ type Global struct {
 	VerifySSL bool   `ini:"verify-ssl"`
 }
 
-var _ = Describe("Client", func() {
+var _ = ginkgo.Describe("Client", func() {
 
 	var (
 		mockCtrl   *gomock.Controller
@@ -47,81 +47,81 @@ var _ = Describe("Client", func() {
 		as         *cloudstack.MockAccountServiceIface
 	)
 
-	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
+	ginkgo.BeforeEach(func() {
+		mockCtrl = gomock.NewController(ginkgo.GinkgoT())
 		mockClient = cloudstack.NewMockClient(mockCtrl)
 		us = mockClient.User.(*cloudstack.MockUserServiceIface)
 		ds = mockClient.Domain.(*cloudstack.MockDomainServiceIface)
 		as = mockClient.Account.(*cloudstack.MockAccountServiceIface)
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 	})
 
-	Context("When fetching a YAML config.", func() {
-		It("Handles the positive case.", func() {
+	ginkgo.Context("When fetching a YAML config.", func() {
+		ginkgo.It("Handles the positive case.", func() {
 			// This test fixture is useful for development, but the actual method of parsing is confinded to the client's
 			// new client method. The parsing used here is more of a schema, and we don't need to test another library's
 			// abilities to parse said schema.
-			Skip("Dev test suite.")
+			ginkgo.Skip("Dev test suite.")
 			// Create a real cloud client.
 			var connectionErr error
 			_, connectionErr = helpers.NewCSClient()
-			Ω(connectionErr).ShouldNot(HaveOccurred())
+			gomega.Ω(connectionErr).ShouldNot(gomega.HaveOccurred())
 
 			_, connectionErr = cloud.NewClientFromYamlPath(os.Getenv("REPO_ROOT")+"/cloud-config.yaml", "myendpoint")
-			Ω(connectionErr).ShouldNot(HaveOccurred())
+			gomega.Ω(connectionErr).ShouldNot(gomega.HaveOccurred())
 		})
 	})
 
-	Context("GetClientCacheTTL", func() {
-		It("Returns the default TTL when a nil is passed", func() {
+	ginkgo.Context("GetClientCacheTTL", func() {
+		ginkgo.It("Returns the default TTL when a nil is passed", func() {
 			result := cloud.GetClientCacheTTL(nil)
-			Ω(result).Should(Equal(cloud.DefaultClientCacheTTL))
+			gomega.Ω(result).Should(gomega.Equal(cloud.DefaultClientCacheTTL))
 		})
 
-		It("Returns the default TTL when an empty config map is passed", func() {
+		ginkgo.It("Returns the default TTL when an empty config map is passed", func() {
 			clientConfig := &corev1.ConfigMap{}
 			result := cloud.GetClientCacheTTL(clientConfig)
-			Ω(result).Should(Equal(cloud.DefaultClientCacheTTL))
+			gomega.Ω(result).Should(gomega.Equal(cloud.DefaultClientCacheTTL))
 		})
 
-		It("Returns the default TTL when the TTL key does not exist", func() {
+		ginkgo.It("Returns the default TTL when the TTL key does not exist", func() {
 			clientConfig := &corev1.ConfigMap{}
 			clientConfig.Data = map[string]string{}
 			clientConfig.Data[cloud.ClientCacheTTLKey+"XXXX"] = "1m5s"
 			result := cloud.GetClientCacheTTL(clientConfig)
-			Ω(result).Should(Equal(cloud.DefaultClientCacheTTL))
+			gomega.Ω(result).Should(gomega.Equal(cloud.DefaultClientCacheTTL))
 		})
 
-		It("Returns the default TTL when the TTL value is invalid", func() {
+		ginkgo.It("Returns the default TTL when the TTL value is invalid", func() {
 			clientConfig := &corev1.ConfigMap{}
 			clientConfig.Data = map[string]string{}
 			clientConfig.Data[cloud.ClientCacheTTLKey] = "5mXXX"
 			result := cloud.GetClientCacheTTL(clientConfig)
-			Ω(result).Should(Equal(cloud.DefaultClientCacheTTL))
+			gomega.Ω(result).Should(gomega.Equal(cloud.DefaultClientCacheTTL))
 		})
 
-		It("Returns the TTL from the input clientConfig map", func() {
+		ginkgo.It("Returns the TTL from the input clientConfig map", func() {
 			clientConfig := &corev1.ConfigMap{}
 			clientConfig.Data = map[string]string{}
 			clientConfig.Data[cloud.ClientCacheTTLKey] = "5m10s"
 			expected, _ := time.ParseDuration("5m10s")
 			result := cloud.GetClientCacheTTL(clientConfig)
-			Ω(result).Should(Equal(expected))
+			gomega.Ω(result).Should(gomega.Equal(expected))
 		})
 	})
 
-	Context("NewClientFromConf", func() {
+	ginkgo.Context("NewClientFromConf", func() {
 		clientConfig := &corev1.ConfigMap{}
-		cloud.NewAsyncClient = func(apiurl, apikey, secret string, verifyssl bool, options ...cloudstack.ClientOption) *cloudstack.CloudStackClient {
+		cloud.NewAsyncClient = func(_, _, _ string, _ bool, _ ...cloudstack.ClientOption) *cloudstack.CloudStackClient {
 			return mockClient
 		}
-		cloud.NewClient = func(apiurl, apikey, secret string, verifyssl bool, options ...cloudstack.ClientOption) *cloudstack.CloudStackClient {
+		cloud.NewClient = func(_, _, _ string, _ bool, _ ...cloudstack.ClientOption) *cloudstack.CloudStackClient {
 			return mockClient
 		}
 
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			clientConfig.Data = map[string]string{}
 			clientConfig.Data[cloud.ClientCacheTTLKey] = "100ms"
 			fakeListParams := &cloudstack.ListUsersParams{}
@@ -158,16 +158,16 @@ var _ = Describe("Client", func() {
 
 		})
 
-		It("Returns a new client", func() {
+		ginkgo.It("Returns a new client", func() {
 			config := cloud.Config{
 				APIUrl: "http://1.1.1.1",
 			}
 			result, err := cloud.NewClientFromConf(config, clientConfig, "")
-			Ω(err).ShouldNot(HaveOccurred())
-			Ω(result).ShouldNot(BeNil())
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Ω(result).ShouldNot(gomega.BeNil())
 		})
 
-		It("Returns a new client for a different config", func() {
+		ginkgo.It("Returns a new client for a different config", func() {
 			config1 := cloud.Config{
 				APIUrl: "http://2.2.2.2",
 			}
@@ -176,10 +176,10 @@ var _ = Describe("Client", func() {
 			}
 			result1, _ := cloud.NewClientFromConf(config1, clientConfig, "")
 			result2, _ := cloud.NewClientFromConf(config2, clientConfig, "")
-			Ω(result1).ShouldNot(Equal(result2))
+			gomega.Ω(result1).ShouldNot(gomega.Equal(result2))
 		})
 
-		It("Returns a cached client for the same config", func() {
+		ginkgo.It("Returns a cached client for the same config", func() {
 			config1 := cloud.Config{
 				APIUrl: "http://4.4.4.4",
 			}
@@ -188,7 +188,7 @@ var _ = Describe("Client", func() {
 			}
 			result1, _ := cloud.NewClientFromConf(config1, clientConfig, "")
 			result2, _ := cloud.NewClientFromConf(config2, clientConfig, "")
-			Ω(result1).Should(Equal(result2))
+			gomega.Ω(result1).Should(gomega.Equal(result2))
 		})
 	})
 })

--- a/pkg/cloud/cloud_suite_test.go
+++ b/pkg/cloud/cloud_suite_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
@@ -39,23 +39,23 @@ var (
 )
 
 func TestCloud(t *testing.T) {
-	RegisterFailHandler(Fail)
-	BeforeSuite(func() {
-		suiteConfig, _ := GinkgoConfiguration()
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.BeforeSuite(func() {
+		suiteConfig, _ := ginkgo.GinkgoConfiguration()
 		if !strings.Contains(suiteConfig.LabelFilter, "!integ") { // Skip if integ tests are filtered out.
 			// Create a real cloud client.
 			var connectionErr error
 			realCSClient, connectionErr = helpers.NewCSClient()
-			Ω(connectionErr).ShouldNot(HaveOccurred())
+			gomega.Ω(connectionErr).ShouldNot(gomega.HaveOccurred())
 
 			repoRoot := os.Getenv("REPO_ROOT")
 			realCloudClient, connectionErr = cloud.NewClientFromYamlPath(
 				repoRoot+"/cloud-config.yaml", "myendpoint")
-			Ω(connectionErr).ShouldNot(HaveOccurred())
+			gomega.Ω(connectionErr).ShouldNot(gomega.HaveOccurred())
 
 			// Create a real CloudStack client.
 			realCSClient, connectionErr = helpers.NewCSClient()
-			Ω(connectionErr).ShouldNot(HaveOccurred())
+			gomega.Ω(connectionErr).ShouldNot(gomega.HaveOccurred())
 
 			// Create a new account and user to run tests that use a real ACS instance.
 			uid := string(uuid.NewUUID())
@@ -63,35 +63,35 @@ func TestCloud(t *testing.T) {
 				Name:   "TestAccount-" + uid,
 				Domain: cloud.Domain{Name: "TestDomain-" + uid, Path: "ROOT/TestDomain-" + uid}}
 			newUser := cloud.User{Account: newAccount}
-			Ω(helpers.GetOrCreateUserWithKey(realCSClient, &newUser)).Should(Succeed())
+			gomega.Ω(helpers.GetOrCreateUserWithKey(realCSClient, &newUser)).Should(gomega.Succeed())
 			testDomainPath = newAccount.Domain.Path
 
-			Ω(newUser.APIKey).ShouldNot(BeEmpty())
+			gomega.Ω(newUser.APIKey).ShouldNot(gomega.BeEmpty())
 
 			// Switch to test account user.
 			realCloudClient, connectionErr = realCloudClient.NewClientInDomainAndAccount(
 				newAccount.Domain.Name, newAccount.Name, "")
-			Ω(connectionErr).ShouldNot(HaveOccurred())
+			gomega.Ω(connectionErr).ShouldNot(gomega.HaveOccurred())
 		}
 	})
-	AfterSuite(func() {
+	ginkgo.AfterSuite(func() {
 		if realCSClient != nil { // Check for nil in case the before suite setup failed.
 			// Delete created domain.
 			id, err, found := helpers.GetDomainByPath(realCSClient, testDomainPath)
-			Ω(err).ShouldNot(HaveOccurred())
-			Ω(found).Should(BeTrue())
-			Ω(helpers.DeleteDomain(realCSClient, id)).Should(Succeed())
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Ω(found).Should(gomega.BeTrue())
+			gomega.Ω(helpers.DeleteDomain(realCSClient, id)).Should(gomega.Succeed())
 		}
 	})
-	RunSpecs(t, "Cloud Suite")
+	ginkgo.RunSpecs(t, "Cloud Suite")
 }
 
 // FetchIntegTestResources runs through basic CloudStack Client setup methods needed to test others.
 func FetchIntegTestResources() {
-	Ω(realCloudClient.ResolveZone(&dummies.CSFailureDomain1.Spec.Zone)).Should(Succeed())
-	Ω(dummies.CSFailureDomain1.Spec.Zone.ID).ShouldNot(BeEmpty())
+	gomega.Ω(realCloudClient.ResolveZone(&dummies.CSFailureDomain1.Spec.Zone)).Should(gomega.Succeed())
+	gomega.Ω(dummies.CSFailureDomain1.Spec.Zone.ID).ShouldNot(gomega.BeEmpty())
 	dummies.CSMachine1.Spec.DiskOffering.Name = ""
 	dummies.CSCluster.Spec.ControlPlaneEndpoint.Host = ""
-	Ω(realCloudClient.GetOrCreateIsolatedNetwork(
-		dummies.CSFailureDomain1, dummies.CSISONet1, dummies.CSCluster)).Should(Succeed())
+	gomega.Ω(realCloudClient.GetOrCreateIsolatedNetwork(
+		dummies.CSFailureDomain1, dummies.CSISONet1, dummies.CSCluster)).Should(gomega.Succeed())
 }

--- a/pkg/cloud/helpers_test.go
+++ b/pkg/cloud/helpers_test.go
@@ -24,7 +24,7 @@ import (
 	"reflect"
 
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/gomega"
+	gomega "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 )
 
@@ -48,7 +48,7 @@ func (p paramMatcher) String() string {
 }
 
 func (p paramMatcher) Matches(x interface{}) (retVal bool) {
-	return Ω(x).Should(p.matcher)
+	return gomega.Ω(x).Should(p.matcher)
 }
 
 // This generates translating matchers.
@@ -61,16 +61,16 @@ func (p paramMatcher) Matches(x interface{}) (retVal bool) {
 //
 //			DomainIDEquals = FieldMatcherGenerator("GetDomainid")
 //	     p := &CreateNewSomethingParams{Domainid: "FakeDomainID"}
-//	     Ω(p).DomainIDEquals("FakeDomainID")
+//	     gomega.Ω(p).DomainIDEquals("FakeDomainID")
 func FieldMatcherGenerator(fetchFunc string) func(string) types.GomegaMatcher {
 	return func(expected string) types.GomegaMatcher {
-		return WithTransform(
+		return gomega.WithTransform(
 			func(x interface{}) string {
 				meth := reflect.ValueOf(x).MethodByName(fetchFunc)
 				fmt.Println(meth.Call(nil)[0])
 
 				return meth.Call(nil)[0].String()
-			}, Equal(expected))
+			}, gomega.Equal(expected))
 	}
 }
 

--- a/pkg/cloud/instance_test.go
+++ b/pkg/cloud/instance_test.go
@@ -22,18 +22,18 @@ import (
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-cloudstack/api/v1beta3"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
 
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"k8s.io/utils/pointer"
 )
 
-var _ = Describe("Instance", func() {
+var _ = ginkgo.Describe("Instance", func() {
 	const (
 		unknownErrorMessage = "unknown err"
 		offeringFakeID      = "123"
@@ -57,8 +57,8 @@ var _ = Describe("Instance", func() {
 		client        cloud.Client
 	)
 
-	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
+	ginkgo.BeforeEach(func() {
+		mockCtrl = gomock.NewController(ginkgo.GinkgoT())
 		mockClient = cloudstack.NewMockClient(mockCtrl)
 		configuration = mockClient.Configuration.(*cloudstack.MockConfigurationServiceIface)
 		vms = mockClient.VirtualMachine.(*cloudstack.MockVirtualMachineServiceIface)
@@ -71,58 +71,58 @@ var _ = Describe("Instance", func() {
 		dummies.SetDummyVars()
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 		mockCtrl.Finish()
 	})
 
-	Context("when fetching a VM instance", func() {
-		It("Handles an unknown error when fetching by ID", func() {
+	ginkgo.Context("when fetching a VM instance", func() {
+		ginkgo.It("Handles an unknown error when fetching by ID", func() {
 			vms.EXPECT().GetVirtualMachinesMetricByID(*dummies.CSMachine1.Spec.InstanceID, gomock.Any()).Return(nil, -1, unknownError)
-			Ω(client.ResolveVMInstanceDetails(dummies.CSMachine1)).To(MatchError(unknownErrorMessage))
+			gomega.Ω(client.ResolveVMInstanceDetails(dummies.CSMachine1)).To(gomega.MatchError(unknownErrorMessage))
 		})
 
-		It("Handles finding more than one VM instance by ID", func() {
+		ginkgo.It("Handles finding more than one VM instance by ID", func() {
 			vms.EXPECT().GetVirtualMachinesMetricByID(*dummies.CSMachine1.Spec.InstanceID, gomock.Any()).Return(nil, 2, nil)
-			Ω(client.ResolveVMInstanceDetails(dummies.CSMachine1)).
-				Should(MatchError("found more than one VM Instance with ID " + *dummies.CSMachine1.Spec.InstanceID))
+			gomega.Ω(client.ResolveVMInstanceDetails(dummies.CSMachine1)).
+				Should(gomega.MatchError("found more than one VM Instance with ID " + *dummies.CSMachine1.Spec.InstanceID))
 		})
 
-		It("sets dummies.CSMachine1 spec and status values when VM instance found by ID", func() {
+		ginkgo.It("sets dummies.CSMachine1 spec and status values when VM instance found by ID", func() {
 			vmsResp := &cloudstack.VirtualMachinesMetric{Id: *dummies.CSMachine1.Spec.InstanceID}
 			vms.EXPECT().GetVirtualMachinesMetricByID(*dummies.CSMachine1.Spec.InstanceID, gomock.Any()).Return(vmsResp, 1, nil)
-			Ω(client.ResolveVMInstanceDetails(dummies.CSMachine1)).Should(Succeed())
-			Ω(dummies.CSMachine1.Spec.ProviderID).Should(Equal(pointer.String("cloudstack:///" + vmsResp.Id)))
-			Ω(dummies.CSMachine1.Spec.InstanceID).Should(Equal(pointer.String(vmsResp.Id)))
+			gomega.Ω(client.ResolveVMInstanceDetails(dummies.CSMachine1)).Should(gomega.Succeed())
+			gomega.Ω(dummies.CSMachine1.Spec.ProviderID).Should(gomega.Equal(pointer.String("cloudstack:///" + vmsResp.Id)))
+			gomega.Ω(dummies.CSMachine1.Spec.InstanceID).Should(gomega.Equal(pointer.String(vmsResp.Id)))
 		})
 
-		It("handles an unknown error when fetching by name", func() {
+		ginkgo.It("handles an unknown error when fetching by name", func() {
 			vms.EXPECT().GetVirtualMachinesMetricByID(*dummies.CSMachine1.Spec.InstanceID, gomock.Any()).Return(nil, -1, notFoundError)
 			vms.EXPECT().GetVirtualMachinesMetricByName(dummies.CSMachine1.Name, gomock.Any()).Return(nil, -1, unknownError)
 
-			Ω(client.ResolveVMInstanceDetails(dummies.CSMachine1)).Should(MatchError(unknownErrorMessage))
+			gomega.Ω(client.ResolveVMInstanceDetails(dummies.CSMachine1)).Should(gomega.MatchError(unknownErrorMessage))
 		})
 
-		It("handles finding more than one VM instance by Name", func() {
+		ginkgo.It("handles finding more than one VM instance by Name", func() {
 			vms.EXPECT().GetVirtualMachinesMetricByID(*dummies.CSMachine1.Spec.InstanceID, gomock.Any()).Return(nil, -1, notFoundError)
 			vms.EXPECT().GetVirtualMachinesMetricByName(dummies.CSMachine1.Name, gomock.Any()).Return(nil, 2, nil)
 
-			Ω(client.ResolveVMInstanceDetails(dummies.CSMachine1)).Should(
-				MatchError("found more than one VM Instance with name " + dummies.CSMachine1.Name))
+			gomega.Ω(client.ResolveVMInstanceDetails(dummies.CSMachine1)).Should(
+				gomega.MatchError("found more than one VM Instance with name " + dummies.CSMachine1.Name))
 		})
 
-		It("sets dummies.CSMachine1 spec and status values when VM instance found by Name", func() {
+		ginkgo.It("sets dummies.CSMachine1 spec and status values when VM instance found by Name", func() {
 			vms.EXPECT().GetVirtualMachinesMetricByID(*dummies.CSMachine1.Spec.InstanceID, gomock.Any()).Return(nil, -1, notFoundError)
 			vms.EXPECT().GetVirtualMachinesMetricByName(dummies.CSMachine1.Name, gomock.Any()).
 				Return(&cloudstack.VirtualMachinesMetric{Id: *dummies.CSMachine1.Spec.InstanceID}, -1, nil)
 
-			Ω(client.ResolveVMInstanceDetails(dummies.CSMachine1)).Should(Succeed())
-			Ω(dummies.CSMachine1.Spec.ProviderID).Should(Equal(
+			gomega.Ω(client.ResolveVMInstanceDetails(dummies.CSMachine1)).Should(gomega.Succeed())
+			gomega.Ω(dummies.CSMachine1.Spec.ProviderID).Should(gomega.Equal(
 				pointer.String(fmt.Sprintf("cloudstack:///%s", *dummies.CSMachine1.Spec.InstanceID))))
-			Ω(dummies.CSMachine1.Spec.InstanceID).Should(Equal(pointer.String(*dummies.CSMachine1.Spec.InstanceID)))
+			gomega.Ω(dummies.CSMachine1.Spec.InstanceID).Should(gomega.Equal(pointer.String(*dummies.CSMachine1.Spec.InstanceID)))
 		})
 	})
 
-	Context("when creating a VM instance", func() {
+	ginkgo.Context("when creating a VM instance", func() {
 		vmMetricResp := &cloudstack.VirtualMachinesMetric{}
 
 		expectVMNotFound := func() {
@@ -130,40 +130,40 @@ var _ = Describe("Instance", func() {
 			vms.EXPECT().GetVirtualMachinesMetricByName(dummies.CSMachine1.Name, gomock.Any()).Return(nil, -1, notFoundError)
 		}
 
-		It("doesn't re-create if one already exists.", func() {
+		ginkgo.It("doesn't re-create if one already exists.", func() {
 			vms.EXPECT().GetVirtualMachinesMetricByID(*dummies.CSMachine1.Spec.InstanceID, gomock.Any()).Return(vmMetricResp, -1, nil)
-			Ω(client.GetOrCreateVMInstance(
+			gomega.Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-				Should(Succeed())
+				Should(gomega.Succeed())
 		})
 
-		It("returns unknown error while fetching VM instance", func() {
+		ginkgo.It("returns unknown error while fetching VM instance", func() {
 			vms.EXPECT().GetVirtualMachinesMetricByID(*dummies.CSMachine1.Spec.InstanceID, gomock.Any()).Return(nil, -1, unknownError)
-			Ω(client.GetOrCreateVMInstance(
+			gomega.Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-				Should(MatchError(unknownErrorMessage))
+				Should(gomega.MatchError(unknownErrorMessage))
 		})
 
-		It("returns errors occurring while fetching service offering information", func() {
+		ginkgo.It("returns errors occurring while fetching service offering information", func() {
 			expectVMNotFound()
 			sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).Return(&cloudstack.ServiceOffering{}, -1, unknownError)
-			Ω(client.GetOrCreateVMInstance(
+			gomega.Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-				ShouldNot(Succeed())
+				ShouldNot(gomega.Succeed())
 		})
 
-		It("returns errors if more than one service offering found", func() {
+		ginkgo.It("returns errors if more than one service offering found", func() {
 			expectVMNotFound()
 			sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).Return(&cloudstack.ServiceOffering{
 				Id:   dummies.CSMachine1.Spec.Offering.ID,
 				Name: dummies.CSMachine1.Spec.Offering.Name,
 			}, 2, nil)
-			Ω(client.GetOrCreateVMInstance(
+			gomega.Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-				ShouldNot(Succeed())
+				ShouldNot(gomega.Succeed())
 		})
 
-		It("returns errors while fetching template", func() {
+		ginkgo.It("returns errors while fetching template", func() {
 			expectVMNotFound()
 
 			sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -173,12 +173,12 @@ var _ = Describe("Instance", func() {
 				}, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID, gomock.Any()).
 				Return("", -1, unknownError)
-			Ω(client.GetOrCreateVMInstance(
+			gomega.Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-				ShouldNot(Succeed())
+				ShouldNot(gomega.Succeed())
 		})
 
-		It("returns errors when more than one template found", func() {
+		ginkgo.It("returns errors when more than one template found", func() {
 			expectVMNotFound()
 
 			sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -187,12 +187,12 @@ var _ = Describe("Instance", func() {
 					Name: dummies.CSMachine1.Spec.Offering.Name,
 				}, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID, gomock.Any()).Return("", 2, nil)
-			Ω(client.GetOrCreateVMInstance(
+			gomega.Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-				ShouldNot(Succeed())
+				ShouldNot(gomega.Succeed())
 		})
 
-		It("returns errors when more than one diskoffering found", func() {
+		ginkgo.It("returns errors when more than one diskoffering found", func() {
 			expectVMNotFound()
 
 			sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -202,12 +202,12 @@ var _ = Describe("Instance", func() {
 				}, 1, nil)
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID, gomock.Any()).Return(dummies.CSMachine1.Spec.Template.ID, 1, nil)
 			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID, 2, nil)
-			Ω(client.GetOrCreateVMInstance(
+			gomega.Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-				ShouldNot(Succeed())
+				ShouldNot(gomega.Succeed())
 		})
 
-		It("returns errors when fetching diskoffering", func() {
+		ginkgo.It("returns errors when fetching diskoffering", func() {
 			expectVMNotFound()
 			sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
 				Return(&cloudstack.ServiceOffering{
@@ -217,12 +217,12 @@ var _ = Describe("Instance", func() {
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID, gomock.Any()).Return(dummies.CSMachine1.Spec.Template.ID, 1, nil)
 			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID, 1, nil)
 			dos.EXPECT().GetDiskOfferingByID(diskOfferingFakeID, gomock.Any()).Return(&cloudstack.DiskOffering{Iscustomized: false}, 1, unknownError)
-			Ω(client.GetOrCreateVMInstance(
+			gomega.Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-				ShouldNot(Succeed())
+				ShouldNot(gomega.Succeed())
 		})
 
-		It("returns errors when disk size not zero for non-customized disk offering", func() {
+		ginkgo.It("returns errors when disk size not zero for non-customized disk offering", func() {
 			expectVMNotFound()
 			dummies.CSMachine1.Spec.DiskOffering.CustomSize = 1
 			sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -233,12 +233,12 @@ var _ = Describe("Instance", func() {
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID, gomock.Any()).Return(dummies.CSMachine1.Spec.Template.ID, 1, nil)
 			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID, 1, nil)
 			dos.EXPECT().GetDiskOfferingByID(diskOfferingFakeID, gomock.Any()).Return(&cloudstack.DiskOffering{Iscustomized: false}, 1, nil)
-			Ω(client.GetOrCreateVMInstance(
+			gomega.Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-				ShouldNot(Succeed())
+				ShouldNot(gomega.Succeed())
 		})
 
-		It("returns errors when disk size zero for customized disk offering", func() {
+		ginkgo.It("returns errors when disk size zero for customized disk offering", func() {
 			expectVMNotFound()
 			dummies.CSMachine1.Spec.DiskOffering.CustomSize = 0
 			sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -251,13 +251,13 @@ var _ = Describe("Instance", func() {
 			ts.EXPECT().GetTemplateID(dummies.CSMachine1.Spec.Template.Name, executableFilter, dummies.Zone1.ID, gomock.Any()).Return(dummies.CSMachine1.Spec.Template.ID, 1, nil)
 			dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID, 1, nil)
 			dos.EXPECT().GetDiskOfferingByID(diskOfferingFakeID, gomock.Any()).Return(&cloudstack.DiskOffering{Iscustomized: true}, 1, nil)
-			Ω(client.GetOrCreateVMInstance(
+			gomega.Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-				ShouldNot(Succeed())
+				ShouldNot(gomega.Succeed())
 		})
 
-		Context("when account & domains have limits", func() {
-			It("returns errors when there are not enough available CPU in account", func() {
+		ginkgo.Context("when account & domains have limits", func() {
+			ginkgo.It("returns errors when there are not enough available CPU in account", func() {
 				expectVMNotFound()
 				dummies.CSMachine1.Spec.DiskOffering.CustomSize = 0
 				sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -286,12 +286,12 @@ var _ = Describe("Instance", func() {
 					},
 				}
 				c := cloud.NewClientFromCSAPIClient(mockClient, user)
-				Ω(c.GetOrCreateVMInstance(
+				gomega.Ω(c.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-					Should(MatchError(MatchRegexp("CPU available .* in account can't fulfil the requirement:.*")))
+					Should(gomega.MatchError(gomega.MatchRegexp("CPU available .* in account can't fulfil the requirement:.*")))
 			})
 
-			It("returns errors when there are not enough available CPU in domain", func() {
+			ginkgo.It("returns errors when there are not enough available CPU in domain", func() {
 				expectVMNotFound()
 				dummies.CSMachine1.Spec.DiskOffering.CustomSize = 0
 				sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -320,12 +320,12 @@ var _ = Describe("Instance", func() {
 					},
 				}
 				c := cloud.NewClientFromCSAPIClient(mockClient, user)
-				Ω(c.GetOrCreateVMInstance(
+				gomega.Ω(c.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-					Should(MatchError(MatchRegexp("CPU available .* in domain can't fulfil the requirement:.*")))
+					Should(gomega.MatchError(gomega.MatchRegexp("CPU available .* in domain can't fulfil the requirement:.*")))
 			})
 
-			It("returns errors when there are not enough available CPU in project", func() {
+			ginkgo.It("returns errors when there are not enough available CPU in project", func() {
 				expectVMNotFound()
 				dummies.CSMachine1.Spec.DiskOffering.CustomSize = 0
 				sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -354,12 +354,12 @@ var _ = Describe("Instance", func() {
 					},
 				}
 				c := cloud.NewClientFromCSAPIClient(mockClient, user)
-				Ω(c.GetOrCreateVMInstance(
+				gomega.Ω(c.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-					Should(MatchError(MatchRegexp("CPU available .* in project can't fulfil the requirement:.*")))
+					Should(gomega.MatchError(gomega.MatchRegexp("CPU available .* in project can't fulfil the requirement:.*")))
 			})
 
-			It("returns errors when there is not enough available memory in account", func() {
+			ginkgo.It("returns errors when there is not enough available memory in account", func() {
 				expectVMNotFound()
 				dummies.CSMachine1.Spec.DiskOffering.CustomSize = 0
 				sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -388,12 +388,12 @@ var _ = Describe("Instance", func() {
 					},
 				}
 				c := cloud.NewClientFromCSAPIClient(mockClient, user)
-				Ω(c.GetOrCreateVMInstance(
+				gomega.Ω(c.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-					Should(MatchError(MatchRegexp("memory available .* in account can't fulfil the requirement:.*")))
+					Should(gomega.MatchError(gomega.MatchRegexp("memory available .* in account can't fulfil the requirement:.*")))
 			})
 
-			It("returns errors when there is not enough available memory in domain", func() {
+			ginkgo.It("returns errors when there is not enough available memory in domain", func() {
 				expectVMNotFound()
 				dummies.CSMachine1.Spec.DiskOffering.CustomSize = 0
 				sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -422,12 +422,12 @@ var _ = Describe("Instance", func() {
 					},
 				}
 				c := cloud.NewClientFromCSAPIClient(mockClient, user)
-				Ω(c.GetOrCreateVMInstance(
+				gomega.Ω(c.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-					Should(MatchError(MatchRegexp("memory available .* in domain can't fulfil the requirement:.*")))
+					Should(gomega.MatchError(gomega.MatchRegexp("memory available .* in domain can't fulfil the requirement:.*")))
 			})
 
-			It("returns errors when there is not enough available memory in project", func() {
+			ginkgo.It("returns errors when there is not enough available memory in project", func() {
 				expectVMNotFound()
 				dummies.CSMachine1.Spec.DiskOffering.CustomSize = 0
 				sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -456,12 +456,12 @@ var _ = Describe("Instance", func() {
 					},
 				}
 				c := cloud.NewClientFromCSAPIClient(mockClient, user)
-				Ω(c.GetOrCreateVMInstance(
+				gomega.Ω(c.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-					Should(MatchError(MatchRegexp("memory available .* in project can't fulfil the requirement:.*")))
+					Should(gomega.MatchError(gomega.MatchRegexp("memory available .* in project can't fulfil the requirement:.*")))
 			})
 
-			It("returns errors when there is not enough available VM limit in account", func() {
+			ginkgo.It("returns errors when there is not enough available VM limit in account", func() {
 				expectVMNotFound()
 				dummies.CSMachine1.Spec.DiskOffering.CustomSize = 0
 				sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -490,12 +490,12 @@ var _ = Describe("Instance", func() {
 					},
 				}
 				c := cloud.NewClientFromCSAPIClient(mockClient, user)
-				Ω(c.GetOrCreateVMInstance(
+				gomega.Ω(c.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-					Should(MatchError("VM Limit in account has reached it's maximum value"))
+					Should(gomega.MatchError("VM Limit in account has reached it's maximum value"))
 			})
 
-			It("returns errors when there is not enough available VM limit in domain", func() {
+			ginkgo.It("returns errors when there is not enough available VM limit in domain", func() {
 				expectVMNotFound()
 				dummies.CSMachine1.Spec.DiskOffering.CustomSize = 0
 				sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -524,12 +524,12 @@ var _ = Describe("Instance", func() {
 					},
 				}
 				c := cloud.NewClientFromCSAPIClient(mockClient, user)
-				Ω(c.GetOrCreateVMInstance(
+				gomega.Ω(c.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-					Should(MatchError("VM Limit in domain has reached it's maximum value"))
+					Should(gomega.MatchError("VM Limit in domain has reached it's maximum value"))
 			})
 
-			It("returns errors when there is not enough available VM limit in project", func() {
+			ginkgo.It("returns errors when there is not enough available VM limit in project", func() {
 				expectVMNotFound()
 				dummies.CSMachine1.Spec.DiskOffering.CustomSize = 0
 				sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
@@ -558,13 +558,13 @@ var _ = Describe("Instance", func() {
 					},
 				}
 				c := cloud.NewClientFromCSAPIClient(mockClient, user)
-				Ω(c.GetOrCreateVMInstance(
+				gomega.Ω(c.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-					Should(MatchError("VM Limit in project has reached it's maximum value"))
+					Should(gomega.MatchError("VM Limit in project has reached it's maximum value"))
 			})
 		})
 
-		It("handles deployment errors", func() {
+		ginkgo.It("handles deployment errors", func() {
 			expectVMNotFound()
 			sos.EXPECT().GetServiceOfferingByName(dummies.CSMachine1.Spec.Offering.Name, gomock.Any()).
 				Return(&cloudstack.ServiceOffering{
@@ -584,13 +584,13 @@ var _ = Describe("Instance", func() {
 			vms.EXPECT().DeployVirtualMachine(gomock.Any()).Return(nil, unknownError)
 			vms.EXPECT().NewListVirtualMachinesParams().Return(&cloudstack.ListVirtualMachinesParams{})
 			vms.EXPECT().ListVirtualMachines(gomock.Any()).Return(&cloudstack.ListVirtualMachinesResponse{}, nil)
-			Ω(client.GetOrCreateVMInstance(
+			gomega.Ω(client.GetOrCreateVMInstance(
 				dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-				Should(MatchError(unknownErrorMessage))
+				Should(gomega.MatchError(unknownErrorMessage))
 		})
 
-		Context("when using UUIDs and/or names to locate service offerings and templates", func() {
-			BeforeEach(func() {
+		ginkgo.Context("when using UUIDs and/or names to locate service offerings and templates", func() {
+			ginkgo.BeforeEach(func() {
 				gomock.InOrder(
 					vms.EXPECT().GetVirtualMachinesMetricByID(*dummies.CSMachine1.Spec.InstanceID, gomock.Any()).
 						Return(nil, -1, notFoundError),
@@ -612,25 +612,25 @@ var _ = Describe("Instance", func() {
 					func(p interface{}) {
 						params := p.(*cloudstack.DeployVirtualMachineParams)
 						displayName, _ := params.GetDisplayname()
-						Ω(displayName == dummies.CAPIMachine.Name).Should(BeTrue())
+						gomega.Ω(displayName == dummies.CAPIMachine.Name).Should(gomega.BeTrue())
 
 						b64UserData, _ := params.GetUserdata()
 
 						userData, err := base64.StdEncoding.DecodeString(b64UserData)
-						Ω(err).ToNot(HaveOccurred())
+						gomega.Ω(err).ToNot(gomega.HaveOccurred())
 
 						decompressedUserData, err := decompress(userData)
-						Ω(err).ToNot(HaveOccurred())
+						gomega.Ω(err).ToNot(gomega.HaveOccurred())
 
-						Ω(string(decompressedUserData)).To(Equal(expectUserData))
+						gomega.Ω(string(decompressedUserData)).To(gomega.Equal(expectUserData))
 					}).Return(deploymentResp, nil)
 
-				Ω(client.GetOrCreateVMInstance(
+				gomega.Ω(client.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, expectUserData)).
-					Should(Succeed())
+					Should(gomega.Succeed())
 			}
 
-			It("works with service offering name and template name", func() {
+			ginkgo.It("works with service offering name and template name", func() {
 				dummies.CSMachine1.Spec.DiskOffering.ID = diskOfferingFakeID
 				dummies.CSMachine1.Spec.Offering.ID = ""
 				dummies.CSMachine1.Spec.Template.ID = ""
@@ -650,7 +650,7 @@ var _ = Describe("Instance", func() {
 				ActionAndAssert()
 			})
 
-			It("works with service offering name and template name without disk offering", func() {
+			ginkgo.It("works with service offering name and template name without disk offering", func() {
 				dummies.CSMachine1.Spec.Offering.ID = ""
 				dummies.CSMachine1.Spec.Template.ID = ""
 				dummies.CSMachine1.Spec.Offering.Name = "offering"
@@ -668,7 +668,7 @@ var _ = Describe("Instance", func() {
 				ActionAndAssert()
 			})
 
-			It("works with service offering ID and template name", func() {
+			ginkgo.It("works with service offering ID and template name", func() {
 				dummies.CSMachine1.Spec.DiskOffering.ID = diskOfferingFakeID
 				dummies.CSMachine1.Spec.Offering.ID = offeringFakeID
 				dummies.CSMachine1.Spec.Template.ID = ""
@@ -688,7 +688,7 @@ var _ = Describe("Instance", func() {
 				ActionAndAssert()
 			})
 
-			It("works with service offering name and template ID", func() {
+			ginkgo.It("works with service offering name and template ID", func() {
 				dummies.CSMachine1.Spec.DiskOffering.ID = diskOfferingFakeID
 				dummies.CSMachine1.Spec.Offering.ID = ""
 				dummies.CSMachine1.Spec.Template.ID = templateFakeID
@@ -708,7 +708,7 @@ var _ = Describe("Instance", func() {
 				ActionAndAssert()
 			})
 
-			It("works with service offering ID and template ID", func() {
+			ginkgo.It("works with service offering ID and template ID", func() {
 				dummies.CSMachine1.Spec.DiskOffering.ID = diskOfferingFakeID
 				dummies.CSMachine1.Spec.Offering.ID = offeringFakeID
 				dummies.CSMachine1.Spec.Template.ID = templateFakeID
@@ -731,7 +731,7 @@ var _ = Describe("Instance", func() {
 				ActionAndAssert()
 			})
 
-			It("works with Id and name both provided", func() {
+			ginkgo.It("works with Id and name both provided", func() {
 				dummies.CSMachine1.Spec.DiskOffering.ID = diskOfferingFakeID
 				dummies.CSMachine1.Spec.Offering.ID = offeringFakeID
 				dummies.CSMachine1.Spec.Template.ID = templateFakeID
@@ -752,14 +752,14 @@ var _ = Describe("Instance", func() {
 			})
 		})
 
-		Context("when using both UUIDs and names to locate service offerings and templates", func() {
-			BeforeEach(func() {
+		ginkgo.Context("when using both UUIDs and names to locate service offerings and templates", func() {
+			ginkgo.BeforeEach(func() {
 				vms.EXPECT().GetVirtualMachinesMetricByID(*dummies.CSMachine1.Spec.InstanceID, gomock.Any()).
 					Return(nil, -1, notFoundError)
 				vms.EXPECT().GetVirtualMachinesMetricByName(dummies.CSMachine1.Name, gomock.Any()).Return(nil, -1, notFoundError)
 			})
 
-			It("works with Id and name both provided, offering name mismatch", func() {
+			ginkgo.It("works with Id and name both provided, offering name mismatch", func() {
 				dummies.CSMachine1.Spec.Offering.ID = offeringFakeID
 				dummies.CSMachine1.Spec.Template.ID = templateFakeID
 				dummies.CSMachine1.Spec.Offering.Name = "offering"
@@ -767,12 +767,12 @@ var _ = Describe("Instance", func() {
 
 				sos.EXPECT().GetServiceOfferingByID(dummies.CSMachine1.Spec.Offering.ID, gomock.Any()).Return(&cloudstack.ServiceOffering{Name: "offering-not-match"}, 1, nil)
 				requiredRegexp := "offering name %s does not match name %s returned using UUID %s"
-				Ω(client.GetOrCreateVMInstance(
+				gomega.Ω(client.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-					Should(MatchError(MatchRegexp(requiredRegexp, dummies.CSMachine1.Spec.Offering.Name, "offering-not-match", offeringFakeID)))
+					Should(gomega.MatchError(gomega.MatchRegexp(requiredRegexp, dummies.CSMachine1.Spec.Offering.Name, "offering-not-match", offeringFakeID)))
 			})
 
-			It("works with Id and name both provided, template name mismatch", func() {
+			ginkgo.It("works with Id and name both provided, template name mismatch", func() {
 				dummies.CSMachine1.Spec.Offering.ID = offeringFakeID
 				dummies.CSMachine1.Spec.Template.ID = templateFakeID
 				dummies.CSMachine1.Spec.Offering.Name = "offering"
@@ -781,12 +781,12 @@ var _ = Describe("Instance", func() {
 				sos.EXPECT().GetServiceOfferingByID(dummies.CSMachine1.Spec.Offering.ID, gomock.Any()).Return(&cloudstack.ServiceOffering{Name: "offering"}, 1, nil)
 				ts.EXPECT().GetTemplateByID(dummies.CSMachine1.Spec.Template.ID, executableFilter, gomock.Any()).Return(&cloudstack.Template{Name: "template-not-match"}, 1, nil)
 				requiredRegexp := "template name %s does not match name %s returned using UUID %s"
-				Ω(client.GetOrCreateVMInstance(
+				gomega.Ω(client.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-					Should(MatchError(MatchRegexp(requiredRegexp, dummies.CSMachine1.Spec.Template.Name, "template-not-match", templateFakeID)))
+					Should(gomega.MatchError(gomega.MatchRegexp(requiredRegexp, dummies.CSMachine1.Spec.Template.Name, "template-not-match", templateFakeID)))
 			})
 
-			It("works with Id and name both provided, disk offering id/name mismatch", func() {
+			ginkgo.It("works with Id and name both provided, disk offering id/name mismatch", func() {
 				dummies.CSMachine1.Spec.Offering.ID = offeringFakeID
 				dummies.CSMachine1.Spec.Template.ID = templateFakeID
 				dummies.CSMachine1.Spec.DiskOffering.ID = diskOfferingFakeID
@@ -798,13 +798,13 @@ var _ = Describe("Instance", func() {
 				ts.EXPECT().GetTemplateByID(dummies.CSMachine1.Spec.Template.ID, executableFilter, gomock.Any()).Return(&cloudstack.Template{Name: "template"}, 1, nil)
 				dos.EXPECT().GetDiskOfferingID(dummies.CSMachine1.Spec.DiskOffering.Name, gomock.Any()).Return(diskOfferingFakeID+"-not-match", 1, nil)
 				requiredRegexp := "diskOffering ID %s does not match ID %s returned using name %s"
-				Ω(client.GetOrCreateVMInstance(
+				gomega.Ω(client.GetOrCreateVMInstance(
 					dummies.CSMachine1, dummies.CAPIMachine, dummies.CSCluster, dummies.CSFailureDomain1, dummies.CSAffinityGroup, "")).
-					Should(MatchError(MatchRegexp(requiredRegexp, dummies.CSMachine1.Spec.DiskOffering.ID, diskOfferingFakeID+"-not-match", dummies.CSMachine1.Spec.DiskOffering.Name)))
+					Should(gomega.MatchError(gomega.MatchRegexp(requiredRegexp, dummies.CSMachine1.Spec.DiskOffering.ID, diskOfferingFakeID+"-not-match", dummies.CSMachine1.Spec.DiskOffering.Name)))
 			})
 		})
 
-		It("doesn't compress user data", func() {
+		ginkgo.It("doesn't compress user data", func() {
 			dummies.CSMachine1.Spec.DiskOffering.ID = diskOfferingFakeID
 			dummies.CSMachine1.Spec.Offering.ID = ""
 			dummies.CSMachine1.Spec.Template.ID = ""
@@ -852,13 +852,13 @@ var _ = Describe("Instance", func() {
 				func(p interface{}) {
 					params := p.(*cloudstack.DeployVirtualMachineParams)
 					displayName, _ := params.GetDisplayname()
-					Ω(displayName == dummies.CAPIMachine.Name).Should(BeTrue())
+					gomega.Ω(displayName == dummies.CAPIMachine.Name).Should(gomega.BeTrue())
 
 					// Ensure the user data is only base64 encoded.
 					b64UserData, _ := params.GetUserdata()
 					userData, err := base64.StdEncoding.DecodeString(b64UserData)
-					Ω(err).ToNot(HaveOccurred())
-					Ω(string(userData)).To(Equal(expectUserData))
+					gomega.Ω(err).ToNot(gomega.HaveOccurred())
+					gomega.Ω(string(userData)).To(gomega.Equal(expectUserData))
 				}).Return(deploymentResp, nil)
 
 			err := client.GetOrCreateVMInstance(
@@ -869,11 +869,11 @@ var _ = Describe("Instance", func() {
 				dummies.CSAffinityGroup,
 				expectUserData,
 			)
-			Ω(err).Should(Succeed())
+			gomega.Ω(err).Should(gomega.Succeed())
 		})
 	})
 
-	Context("when destroying a VM instance", func() {
+	ginkgo.Context("when destroying a VM instance", func() {
 		listCapabilitiesParams := &cloudstack.ListCapabilitiesParams{}
 		expungeDestroyParams := &cloudstack.DestroyVirtualMachineParams{}
 		expungeDestroyParams.SetExpunge(true)
@@ -892,12 +892,12 @@ var _ = Describe("Instance", func() {
 			},
 		}
 
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			configuration.EXPECT().NewListCapabilitiesParams().Return(listCapabilitiesParams)
 			configuration.EXPECT().ListCapabilities(listCapabilitiesParams).Return(listCapabilitiesResponse, nil)
 		})
 
-		It("calls destroy and finds VM doesn't exist, then returns nil", func() {
+		ginkgo.It("calls destroy and finds VM doesn't exist, then returns nil", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
 			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
@@ -905,11 +905,11 @@ var _ = Describe("Instance", func() {
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, fmt.Errorf("unable to find uuid for id"))
 			vs.EXPECT().NewListVolumesParams().Return(listVolumesParams)
 			vs.EXPECT().ListVolumes(listVolumesParams).Return(listVolumesResponse, nil)
-			Ω(client.DestroyVMInstance(dummies.CSMachine1)).
-				Should(Succeed())
+			gomega.Ω(client.DestroyVMInstance(dummies.CSMachine1)).
+				Should(gomega.Succeed())
 		})
 
-		It("calls destroy and returns unexpected error", func() {
+		ginkgo.It("calls destroy and returns unexpected error", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
 			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
@@ -917,10 +917,10 @@ var _ = Describe("Instance", func() {
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, fmt.Errorf("new error"))
 			vs.EXPECT().NewListVolumesParams().Return(listVolumesParams)
 			vs.EXPECT().ListVolumes(listVolumesParams).Return(listVolumesResponse, nil)
-			Ω(client.DestroyVMInstance(dummies.CSMachine1)).Should(MatchError("new error"))
+			gomega.Ω(client.DestroyVMInstance(dummies.CSMachine1)).Should(gomega.MatchError("new error"))
 		})
 
-		It("calls destroy without error but cannot resolve VM after", func() {
+		ginkgo.It("calls destroy without error but cannot resolve VM after", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
 			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
@@ -930,11 +930,11 @@ var _ = Describe("Instance", func() {
 			vs.EXPECT().ListVolumes(listVolumesParams).Return(listVolumesResponse, nil)
 			vms.EXPECT().GetVirtualMachinesMetricByID(*dummies.CSMachine1.Spec.InstanceID, gomock.Any()).Return(nil, -1, notFoundError)
 			vms.EXPECT().GetVirtualMachinesMetricByName(dummies.CSMachine1.Name, gomock.Any()).Return(nil, -1, notFoundError)
-			Ω(client.DestroyVMInstance(dummies.CSMachine1)).
-				Should(Succeed())
+			gomega.Ω(client.DestroyVMInstance(dummies.CSMachine1)).
+				Should(gomega.Succeed())
 		})
 
-		It("calls destroy without error and identifies it as expunging", func() {
+		ginkgo.It("calls destroy without error and identifies it as expunging", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
 			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
@@ -946,11 +946,11 @@ var _ = Describe("Instance", func() {
 				Return(&cloudstack.VirtualMachinesMetric{
 					State: "Expunging",
 				}, 1, nil)
-			Ω(client.DestroyVMInstance(dummies.CSMachine1)).
-				Should(Succeed())
+			gomega.Ω(client.DestroyVMInstance(dummies.CSMachine1)).
+				Should(gomega.Succeed())
 		})
 
-		It("calls destroy without error and identifies it as expunged", func() {
+		ginkgo.It("calls destroy without error and identifies it as expunged", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
 			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
@@ -962,11 +962,11 @@ var _ = Describe("Instance", func() {
 				Return(&cloudstack.VirtualMachinesMetric{
 					State: "Expunged",
 				}, 1, nil)
-			Ω(client.DestroyVMInstance(dummies.CSMachine1)).
-				Should(Succeed())
+			gomega.Ω(client.DestroyVMInstance(dummies.CSMachine1)).
+				Should(gomega.Succeed())
 		})
 
-		It("calls destroy without error and identifies it as stopping", func() {
+		ginkgo.It("calls destroy without error and identifies it as stopping", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
 			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
@@ -978,7 +978,7 @@ var _ = Describe("Instance", func() {
 				Return(&cloudstack.VirtualMachinesMetric{
 					State: "Stopping",
 				}, 1, nil)
-			Ω(client.DestroyVMInstance(dummies.CSMachine1)).Should(MatchError("VM deletion in progress"))
+			gomega.Ω(client.DestroyVMInstance(dummies.CSMachine1)).Should(gomega.MatchError("VM deletion in progress"))
 		})
 	})
 })

--- a/pkg/cloud/isolated_network.go
+++ b/pkg/cloud/isolated_network.go
@@ -30,14 +30,14 @@ type IsoNetworkIface interface {
 	GetOrCreateIsolatedNetwork(*infrav1.CloudStackFailureDomain, *infrav1.CloudStackIsolatedNetwork, *infrav1.CloudStackCluster) error
 
 	AssociatePublicIPAddress(*infrav1.CloudStackFailureDomain, *infrav1.CloudStackIsolatedNetwork, *infrav1.CloudStackCluster) error
-	GetOrCreateLoadBalancerRule(*infrav1.CloudStackFailureDomain, *infrav1.CloudStackIsolatedNetwork, *infrav1.CloudStackCluster) error
+	GetOrCreateLoadBalancerRule(*infrav1.CloudStackIsolatedNetwork, *infrav1.CloudStackCluster) error
 	OpenFirewallRules(*infrav1.CloudStackIsolatedNetwork) error
-	GetPublicIP(*infrav1.CloudStackFailureDomain, *infrav1.CloudStackIsolatedNetwork, *infrav1.CloudStackCluster) (*cloudstack.PublicIpAddress, error)
-	ResolveLoadBalancerRuleDetails(*infrav1.CloudStackFailureDomain, *infrav1.CloudStackIsolatedNetwork, *infrav1.CloudStackCluster) error
+	GetPublicIP(*infrav1.CloudStackFailureDomain, *infrav1.CloudStackCluster) (*cloudstack.PublicIpAddress, error)
+	ResolveLoadBalancerRuleDetails(*infrav1.CloudStackIsolatedNetwork) error
 
 	AssignVMToLoadBalancerRule(isoNet *infrav1.CloudStackIsolatedNetwork, instanceID string) error
 	DeleteNetwork(infrav1.Network) error
-	DisposeIsoNetResources(*infrav1.CloudStackFailureDomain, *infrav1.CloudStackIsolatedNetwork, *infrav1.CloudStackCluster) error
+	DisposeIsoNetResources(*infrav1.CloudStackIsolatedNetwork, *infrav1.CloudStackCluster) error
 }
 
 // getOfferingID fetches an offering id.
@@ -59,7 +59,7 @@ func (c *client) AssociatePublicIPAddress(
 	csCluster *infrav1.CloudStackCluster,
 ) (retErr error) {
 	// Check specified IP address is available or get an unused one if not specified.
-	publicAddress, err := c.GetPublicIP(fd, isoNet, csCluster)
+	publicAddress, err := c.GetPublicIP(fd, csCluster)
 	if err != nil {
 		return errors.Wrapf(err, "fetching a public IP address")
 	}
@@ -141,7 +141,6 @@ func (c *client) OpenFirewallRules(isoNet *infrav1.CloudStackIsolatedNetwork) (r
 // GetPublicIP gets a public IP with ID for cluster endpoint.
 func (c *client) GetPublicIP(
 	fd *infrav1.CloudStackFailureDomain,
-	isoNet *infrav1.CloudStackIsolatedNetwork,
 	csCluster *infrav1.CloudStackCluster,
 ) (*cloudstack.PublicIpAddress, error) {
 	ip := csCluster.Spec.ControlPlaneEndpoint.Host
@@ -196,9 +195,7 @@ func (c *client) GetIsolatedNetwork(isoNet *infrav1.CloudStackIsolatedNetwork) (
 
 // ResolveLoadBalancerRuleDetails resolves the details of a load balancer rule by PublicIPID and Port.
 func (c *client) ResolveLoadBalancerRuleDetails(
-	fd *infrav1.CloudStackFailureDomain,
 	isoNet *infrav1.CloudStackIsolatedNetwork,
-	csCluster *infrav1.CloudStackCluster,
 ) error {
 	p := c.cs.LoadBalancer.NewListLoadBalancerRulesParams()
 	p.SetPublicipid(isoNet.Status.PublicIPID)
@@ -220,7 +217,6 @@ func (c *client) ResolveLoadBalancerRuleDetails(
 
 // GetOrCreateLoadBalancerRule Create a load balancer rule that can be assigned to instances.
 func (c *client) GetOrCreateLoadBalancerRule(
-	fd *infrav1.CloudStackFailureDomain,
 	isoNet *infrav1.CloudStackIsolatedNetwork,
 	csCluster *infrav1.CloudStackCluster,
 ) (retErr error) {
@@ -236,7 +232,7 @@ func (c *client) GetOrCreateLoadBalancerRule(
 	}
 
 	// Check if rule exists.
-	if err := c.ResolveLoadBalancerRuleDetails(fd, isoNet, csCluster); err == nil ||
+	if err := c.ResolveLoadBalancerRuleDetails(isoNet); err == nil ||
 		!strings.Contains(strings.ToLower(err.Error()), "no load balancer rule found") {
 		return errors.Wrap(err, "resolving load balancer rule details")
 	}
@@ -285,7 +281,7 @@ func (c *client) GetOrCreateIsolatedNetwork(
 	}
 
 	// Setup a load balancing rule to map VMs to Public IP.
-	if err := c.GetOrCreateLoadBalancerRule(fd, isoNet, csCluster); err != nil {
+	if err := c.GetOrCreateLoadBalancerRule(isoNet, csCluster); err != nil {
 		return errors.Wrap(err, "getting or creating load balancing rule")
 	}
 
@@ -326,7 +322,6 @@ func (c *client) DeleteNetwork(net infrav1.Network) error {
 
 // DisposeIsoNetResources cleans up isolated network resources.
 func (c *client) DisposeIsoNetResources(
-	zone *infrav1.CloudStackFailureDomain,
 	isoNet *infrav1.CloudStackIsolatedNetwork,
 	csCluster *infrav1.CloudStackCluster,
 ) (retError error) {
@@ -341,15 +336,12 @@ func (c *client) DisposeIsoNetResources(
 	if err := c.RemoveClusterTagFromNetwork(csCluster, *isoNet.Network()); err != nil {
 		return err
 	}
-	if err := c.DeleteNetworkIfNotInUse(csCluster, *isoNet.Network()); err != nil {
-		return err
-	}
-
-	return nil
+	err := c.DeleteNetworkIfNotInUse(*isoNet.Network())
+	return err
 }
 
 // DeleteNetworkIfNotInUse deletes an isolated network if the network is no longer in use (indicated by in use tags).
-func (c *client) DeleteNetworkIfNotInUse(csCluster *infrav1.CloudStackCluster, net infrav1.Network) (retError error) {
+func (c *client) DeleteNetworkIfNotInUse(net infrav1.Network) (retError error) {
 	tags, err := c.GetTags(ResourceTypeNetwork, net.ID)
 	if err != nil {
 		return err

--- a/pkg/cloud/network_test.go
+++ b/pkg/cloud/network_test.go
@@ -22,13 +22,13 @@ import (
 
 	csapi "github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
 )
 
-var _ = Describe("Network", func() {
+var _ = ginkgo.Describe("Network", func() {
 	var ( // Declare shared vars.
 		mockCtrl   *gomock.Controller
 		mockClient *csapi.CloudStackClient
@@ -37,9 +37,9 @@ var _ = Describe("Network", func() {
 		client     cloud.Client
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		// Setup new mock services.
-		mockCtrl = gomock.NewController(GinkgoT())
+		mockCtrl = gomock.NewController(ginkgo.GinkgoT())
 		mockClient = csapi.NewMockClient(mockCtrl)
 		ns = mockClient.Network.(*csapi.MockNetworkServiceIface)
 		rs = mockClient.Resourcetags.(*csapi.MockResourcetagsServiceIface)
@@ -47,35 +47,35 @@ var _ = Describe("Network", func() {
 		dummies.SetDummyVars()
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 		mockCtrl.Finish()
 	})
 
-	Context("for an existing network", func() {
-		It("resolves network by ID", func() {
+	ginkgo.Context("for an existing network", func() {
+		ginkgo.It("resolves network by ID", func() {
 			ns.EXPECT().GetNetworkByName(dummies.ISONet1.Name, gomock.Any()).Return(nil, 0, nil)
 			ns.EXPECT().GetNetworkByID(dummies.ISONet1.ID, gomock.Any()).Return(dummies.CAPCNetToCSAPINet(&dummies.ISONet1), 1, nil)
 
-			Ω(client.ResolveNetwork(&dummies.ISONet1)).Should(Succeed())
+			gomega.Ω(client.ResolveNetwork(&dummies.ISONet1)).Should(gomega.Succeed())
 		})
 
-		It("resolves network by Name", func() {
+		ginkgo.It("resolves network by Name", func() {
 			ns.EXPECT().GetNetworkByName(dummies.ISONet1.Name, gomock.Any()).Return(dummies.CAPCNetToCSAPINet(&dummies.ISONet1), 1, nil)
 
-			Ω(client.ResolveNetwork(&dummies.ISONet1)).Should(Succeed())
+			gomega.Ω(client.ResolveNetwork(&dummies.ISONet1)).Should(gomega.Succeed())
 		})
 
-		It("When there exists more than one network with the same name", func() {
+		ginkgo.It("When there exists more than one network with the same name", func() {
 			ns.EXPECT().GetNetworkByName(dummies.ISONet1.Name, gomock.Any()).Return(dummies.CAPCNetToCSAPINet(&dummies.ISONet1), 2, nil)
 			ns.EXPECT().GetNetworkByID(dummies.ISONet1.ID, gomock.Any()).Return(nil, 2, errors.New("There is more then one result for Network UUID"))
 			err := client.ResolveNetwork(&dummies.ISONet1)
-			Ω(err).ShouldNot(Succeed())
-			Ω(err.Error()).Should(ContainSubstring(fmt.Sprintf("expected 1 Network with name %s, but got %d", dummies.ISONet1.Name, 2)))
+			gomega.Ω(err).ShouldNot(gomega.Succeed())
+			gomega.Ω(err.Error()).Should(gomega.ContainSubstring(fmt.Sprintf("expected 1 Network with name %s, but got %d", dummies.ISONet1.Name, 2)))
 		})
 	})
 
-	Context("Remove cluster tag from network", func() {
-		It("Remove tag from network", func() {
+	ginkgo.Context("Remove cluster tag from network", func() {
+		ginkgo.It("Remove tag from network", func() {
 			rtdp := &csapi.DeleteTagsParams{}
 			createdByCAPCResponse := &csapi.ListTagsResponse{Tags: []*csapi.Tag{{Key: dummies.CSClusterTagKey, Value: "1"}}}
 			rtlp := &csapi.ListTagsParams{}
@@ -83,7 +83,7 @@ var _ = Describe("Network", func() {
 			rs.EXPECT().DeleteTags(rtdp).Return(&csapi.DeleteTagsResponse{}, nil)
 			rs.EXPECT().NewListTagsParams().Return(rtlp)
 			rs.EXPECT().ListTags(rtlp).Return(createdByCAPCResponse, nil)
-			Ω(client.RemoveClusterTagFromNetwork(dummies.CSCluster, dummies.ISONet1)).Should(Succeed())
+			gomega.Ω(client.RemoveClusterTagFromNetwork(dummies.CSCluster, dummies.ISONet1)).Should(gomega.Succeed())
 		})
 	})
 })

--- a/pkg/cloud/tags_test.go
+++ b/pkg/cloud/tags_test.go
@@ -19,14 +19,14 @@ package cloud_test
 import (
 	csapi "github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
 )
 
-var _ = Describe("Tag Unit Tests", func() {
+var _ = ginkgo.Describe("Tag Unit Tests", func() {
 	const (
 		errorMessage = "Error"
 	)
@@ -39,120 +39,120 @@ var _ = Describe("Tag Unit Tests", func() {
 		client     cloud.Client
 	)
 
-	BeforeEach(func() {
+	ginkgo.BeforeEach(func() {
 		dummies.SetDummyVars()
-		mockCtrl = gomock.NewController(GinkgoT())
+		mockCtrl = gomock.NewController(ginkgo.GinkgoT())
 		mockClient = csapi.NewMockClient(mockCtrl)
 		rs = mockClient.Resourcetags.(*csapi.MockResourcetagsServiceIface)
 		client = cloud.NewClientFromCSAPIClient(mockClient, nil)
 	})
 
-	Context("Tag Integ Tests", Label("integ"), func() {
-		BeforeEach(func() {
+	ginkgo.Context("Tag Integ Tests", ginkgo.Label("integ"), func() {
+		ginkgo.BeforeEach(func() {
 			client = realCloudClient
 			FetchIntegTestResources()
 
 			existingTags, err := client.GetTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)
 			if err != nil {
-				Fail("Failed to get existing tags. Error: " + err.Error())
+				ginkgo.Fail("Failed to get existing tags. Error: " + err.Error())
 			}
 			if len(existingTags) > 0 {
 				err = client.DeleteTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, existingTags)
 				if err != nil {
-					Fail("Failed to delete existing tags. Error: " + err.Error())
+					ginkgo.Fail("Failed to delete existing tags. Error: " + err.Error())
 				}
 			}
 		})
 
-		It("adds and gets a resource tag", func() {
-			Ω(client.AddTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.Tags)).Should(Succeed())
-			Ω(client.GetTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(Equal(dummies.Tags))
+		ginkgo.It("adds and gets a resource tag", func() {
+			gomega.Ω(client.AddTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.Tags)).Should(gomega.Succeed())
+			gomega.Ω(client.GetTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(gomega.Equal(dummies.Tags))
 		})
 
-		It("deletes a resource tag", func() {
-			Ω(client.AddTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.Tags)).Should(Succeed())
-			Ω(client.DeleteTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.Tags)).Should(Succeed())
-			Ω(client.GetTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(Equal(map[string]string{}))
+		ginkgo.It("deletes a resource tag", func() {
+			gomega.Ω(client.AddTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.Tags)).Should(gomega.Succeed())
+			gomega.Ω(client.DeleteTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.Tags)).Should(gomega.Succeed())
+			gomega.Ω(client.GetTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(gomega.Equal(map[string]string{}))
 		})
 
-		It("returns an error when you delete a tag that doesn't exist", func() {
-			Ω(client.DeleteTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.Tags)).Should(Succeed())
+		ginkgo.It("returns an error when you delete a tag that doesn't exist", func() {
+			gomega.Ω(client.DeleteTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.Tags)).Should(gomega.Succeed())
 		})
 
-		It("adds the tags for a cluster (resource created by CAPC)", func() {
-			Ω(client.AddCreatedByCAPCTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).
-				Should(Succeed())
-			Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).
-				Should(Succeed())
+		ginkgo.It("adds the tags for a cluster (resource created by CAPC)", func() {
+			gomega.Ω(client.AddCreatedByCAPCTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).
+				Should(gomega.Succeed())
+			gomega.Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).
+				Should(gomega.Succeed())
 
 			// Verify tags
 			tags, err := client.GetTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)
-			Ω(err).ShouldNot(HaveOccurred())
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
 
-			Ω(tags[dummies.CSClusterTagKey]).Should(Equal(dummies.CSClusterTagVal))
+			gomega.Ω(tags[dummies.CSClusterTagKey]).Should(gomega.Equal(dummies.CSClusterTagVal))
 		})
 
-		It("does not fail when the cluster tags are added twice", func() {
-			Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(Succeed())
-			Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(Succeed())
+		ginkgo.It("does not fail when the cluster tags are added twice", func() {
+			gomega.Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(gomega.Succeed())
+			gomega.Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(gomega.Succeed())
 		})
 
-		It("doesn't adds the tags for a cluster (resource NOT created by CAPC)", func() {
-			Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(Succeed())
+		ginkgo.It("doesn't adds the tags for a cluster (resource NOT created by CAPC)", func() {
+			gomega.Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(gomega.Succeed())
 
 			// Verify tags
 			tags, err := client.GetTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)
-			Ω(err).Should(BeNil())
-			Ω(tags[dummies.CreatedByCapcKey]).Should(Equal(""))
-			Ω(tags[dummies.CSClusterTagKey]).Should(Equal(""))
+			gomega.Ω(err).Should(gomega.BeNil())
+			gomega.Ω(tags[dummies.CreatedByCapcKey]).Should(gomega.Equal(""))
+			gomega.Ω(tags[dummies.CSClusterTagKey]).Should(gomega.Equal(""))
 		})
 
-		It("deletes a cluster tag", func() {
-			Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(Succeed())
-			Ω(client.DeleteClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(Succeed())
+		ginkgo.It("deletes a cluster tag", func() {
+			gomega.Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(gomega.Succeed())
+			gomega.Ω(client.DeleteClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(gomega.Succeed())
 
-			Ω(client.GetTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).ShouldNot(HaveKey(dummies.CSClusterTagKey))
+			gomega.Ω(client.GetTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).ShouldNot(gomega.HaveKey(dummies.CSClusterTagKey))
 		})
 
-		It("adds and deletes a created by capc tag", func() {
-			Ω(client.AddCreatedByCAPCTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(Succeed())
-			Ω(client.DeleteCreatedByCAPCTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(Succeed())
+		ginkgo.It("adds and deletes a created by capc tag", func() {
+			gomega.Ω(client.AddCreatedByCAPCTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(gomega.Succeed())
+			gomega.Ω(client.DeleteCreatedByCAPCTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(gomega.Succeed())
 		})
 
-		It("does not fail when cluster and CAPC created tags are deleted twice", func() {
-			Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(Succeed())
-			Ω(client.DeleteClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(Succeed())
-			Ω(client.DeleteClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(Succeed())
-			Ω(client.DeleteCreatedByCAPCTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(Succeed())
-			Ω(client.DeleteCreatedByCAPCTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(Succeed())
+		ginkgo.It("does not fail when cluster and CAPC created tags are deleted twice", func() {
+			gomega.Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(gomega.Succeed())
+			gomega.Ω(client.DeleteClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(gomega.Succeed())
+			gomega.Ω(client.DeleteClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(gomega.Succeed())
+			gomega.Ω(client.DeleteCreatedByCAPCTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(gomega.Succeed())
+			gomega.Ω(client.DeleteCreatedByCAPCTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(gomega.Succeed())
 		})
 
-		It("does not allow a resource to be deleted when there are no tags", func() {
+		ginkgo.It("does not allow a resource to be deleted when there are no tags", func() {
 			tagsAllowDisposal, err := client.DoClusterTagsAllowDisposal(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)
-			Ω(err).Should(BeNil())
-			Ω(tagsAllowDisposal).Should(BeFalse())
+			gomega.Ω(err).Should(gomega.BeNil())
+			gomega.Ω(tagsAllowDisposal).Should(gomega.BeFalse())
 		})
 
-		It("does not allow a resource to be deleted when there is a cluster tag", func() {
-			Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(Succeed())
+		ginkgo.It("does not allow a resource to be deleted when there is a cluster tag", func() {
+			gomega.Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(gomega.Succeed())
 			tagsAllowDisposal, err := client.DoClusterTagsAllowDisposal(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)
-			Ω(err).Should(BeNil())
-			Ω(tagsAllowDisposal).Should(BeFalse())
+			gomega.Ω(err).Should(gomega.BeNil())
+			gomega.Ω(tagsAllowDisposal).Should(gomega.BeFalse())
 		})
 
-		It("does allow a resource to be deleted when there are no cluster tags and there is a CAPC created tag", func() {
-			Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(Succeed())
-			Ω(client.AddCreatedByCAPCTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(Succeed())
-			Ω(client.DeleteClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(Succeed())
+		ginkgo.It("does allow a resource to be deleted when there are no cluster tags and there is a CAPC created tag", func() {
+			gomega.Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(gomega.Succeed())
+			gomega.Ω(client.AddCreatedByCAPCTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)).Should(gomega.Succeed())
+			gomega.Ω(client.DeleteClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(gomega.Succeed())
 
 			tagsAllowDisposal, err := client.DoClusterTagsAllowDisposal(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID)
-			Ω(err).Should(BeNil())
-			Ω(tagsAllowDisposal).Should(BeTrue())
+			gomega.Ω(err).Should(gomega.BeNil())
+			gomega.Ω(tagsAllowDisposal).Should(gomega.BeTrue())
 		})
 	})
 
-	Context("Add cluster tag", func() {
-		It("Add cluster tag if managed by CAPC", func() {
+	ginkgo.Context("Add cluster tag", func() {
+		ginkgo.It("Add cluster tag if managed by CAPC", func() {
 			createdByCAPCResponse := &csapi.ListTagsResponse{Tags: []*csapi.Tag{{Key: cloud.CreatedByCAPCTagName, Value: "1"}}}
 			rtlp := &csapi.ListTagsParams{}
 			ctp := &csapi.CreateTagsParams{}
@@ -160,12 +160,12 @@ var _ = Describe("Tag Unit Tests", func() {
 			rs.EXPECT().ListTags(rtlp).Return(createdByCAPCResponse, nil)
 			rs.EXPECT().NewCreateTagsParams(gomock.Any(), gomock.Any(), gomock.Any()).Return(ctp)
 			rs.EXPECT().CreateTags(ctp).Return(&csapi.CreateTagsResponse{}, nil)
-			Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(Succeed())
+			gomega.Ω(client.AddClusterTag(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, dummies.CSCluster)).Should(gomega.Succeed())
 		})
 	})
 
-	Context("Delete tags", func() {
-		It("delete resource tags fails", func() {
+	ginkgo.Context("Delete tags", func() {
+		ginkgo.It("delete resource tags fails", func() {
 			tags := map[string]string{
 				"key1": "value1",
 			}
@@ -182,18 +182,18 @@ var _ = Describe("Tag Unit Tests", func() {
 			}, nil)
 
 			err := client.DeleteTags(cloud.ResourceTypeNetwork, dummies.CSISONet1.Spec.ID, tags)
-			Ω(err).ShouldNot(Succeed())
-			Ω(err.Error()).Should(ContainSubstring("could not remove tag"))
+			gomega.Ω(err).ShouldNot(gomega.Succeed())
+			gomega.Ω(err.Error()).Should(gomega.ContainSubstring("could not remove tag"))
 		})
 	})
 
-	Context("Get tags for a resource", func() {
-		It("listing tags for a resource fails", func() {
+	ginkgo.Context("Get tags for a resource", func() {
+		ginkgo.It("listing tags for a resource fails", func() {
 			rs.EXPECT().NewListTagsParams().Return(&csapi.ListTagsParams{})
 			rs.EXPECT().ListTags(gomock.Any()).Return(nil, fakeError)
 
 			_, err := client.GetTags(cloud.ResourceTypeNetwork, dummies.ISONet1.ID)
-			Ω(err).ShouldNot(Succeed())
+			gomega.Ω(err).ShouldNot(gomega.Succeed())
 		})
 	})
 })

--- a/pkg/cloud/user_credentials_test.go
+++ b/pkg/cloud/user_credentials_test.go
@@ -22,15 +22,15 @@ import (
 
 	csapi "github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/test/helpers"
 
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 )
 
-var _ = Describe("User Credentials", func() {
+var _ = ginkgo.Describe("User Credentials", func() {
 	const (
 		errorMessage = "Error"
 	)
@@ -44,8 +44,8 @@ var _ = Describe("User Credentials", func() {
 		us         *csapi.MockUserServiceIface
 	)
 
-	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
+	ginkgo.BeforeEach(func() {
+		mockCtrl = gomock.NewController(ginkgo.GinkgoT())
 		mockClient = csapi.NewMockClient(mockCtrl)
 		ds = mockClient.Domain.(*csapi.MockDomainServiceIface)
 		as = mockClient.Account.(*csapi.MockAccountServiceIface)
@@ -57,12 +57,12 @@ var _ = Describe("User Credentials", func() {
 		dummies.SetDummyCAPCClusterVars()
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 		mockCtrl.Finish()
 	})
 
-	Context("Get domain in CloudStack", func() {
-		It("search for CloudStack domain", func() {
+	ginkgo.Context("Get domain in CloudStack", func() {
+		ginkgo.It("search for CloudStack domain", func() {
 			dummies.Domain.Path = "domainPath1"
 			dsp := &csapi.ListDomainsParams{}
 			ds.EXPECT().NewListDomainsParams().Return(dsp)
@@ -71,10 +71,10 @@ var _ = Describe("User Credentials", func() {
 				Path: "ROOT/domainPath1",
 			}}}, nil)
 
-			Ω(client.ResolveDomain(&dummies.Domain)).Should(Succeed())
+			gomega.Ω(client.ResolveDomain(&dummies.Domain)).Should(gomega.Succeed())
 		})
 
-		It("search for CloudStack domain with incorrect domain path", func() {
+		ginkgo.It("search for CloudStack domain with incorrect domain path", func() {
 			dummies.Domain.Path = "/domainPath1"
 			dsp := &csapi.ListDomainsParams{}
 			ds.EXPECT().NewListDomainsParams().Return(dsp)
@@ -84,11 +84,11 @@ var _ = Describe("User Credentials", func() {
 			}}}, nil)
 
 			err := client.ResolveDomain(&dummies.Domain)
-			Ω(err).ShouldNot(Succeed())
-			Ω(err.Error()).Should(Equal(fmt.Sprintf("domain Path %s did not match domain ID %s", dummies.Domain.Path, dummies.Domain.ID)))
+			gomega.Ω(err).ShouldNot(gomega.Succeed())
+			gomega.Ω(err.Error()).Should(gomega.Equal(fmt.Sprintf("domain Path %s did not match domain ID %s", dummies.Domain.Path, dummies.Domain.ID)))
 		})
 
-		It("search for CloudStack domain returns more than one domain", func() {
+		ginkgo.It("search for CloudStack domain returns more than one domain", func() {
 			dummies.Domain.Path = "domainPath1"
 			dsp := &csapi.ListDomainsParams{}
 			ds.EXPECT().NewListDomainsParams().Return(dsp)
@@ -98,11 +98,11 @@ var _ = Describe("User Credentials", func() {
 			}}}, nil)
 
 			err := client.ResolveDomain(&dummies.Domain)
-			Ω(err).ShouldNot(Succeed())
-			Ω(err.Error()).Should(Equal(fmt.Sprintf("domain ID %s provided, expected exactly one domain, got %d", dummies.Domain.ID, 2)))
+			gomega.Ω(err).ShouldNot(gomega.Succeed())
+			gomega.Ω(err.Error()).Should(gomega.Equal(fmt.Sprintf("domain ID %s provided, expected exactly one domain, got %d", dummies.Domain.ID, 2)))
 		})
 
-		It("search for CloudStack domain when only domain Name is provided", func() {
+		ginkgo.It("search for CloudStack domain when only domain Name is provided", func() {
 			dummies.Domain.ID = ""
 			dsp := &csapi.ListDomainsParams{}
 			ds.EXPECT().NewListDomainsParams().Return(dsp)
@@ -110,10 +110,10 @@ var _ = Describe("User Credentials", func() {
 				Name: "domainName",
 			}}}, nil)
 
-			Ω(client.ResolveDomain(&dummies.Domain)).Should(Succeed())
+			gomega.Ω(client.ResolveDomain(&dummies.Domain)).Should(gomega.Succeed())
 		})
 
-		It("search for CloudStack domain when only domain Name is provided, but returns > 1 domain", func() {
+		ginkgo.It("search for CloudStack domain when only domain Name is provided, but returns > 1 domain", func() {
 			dummies.Domain.ID = ""
 			dsp := &csapi.ListDomainsParams{}
 			ds.EXPECT().NewListDomainsParams().Return(dsp)
@@ -122,13 +122,13 @@ var _ = Describe("User Credentials", func() {
 			}}}, nil)
 
 			err := client.ResolveDomain(&dummies.Domain)
-			Ω(err).ShouldNot(Succeed())
-			Ω(err.Error()).Should(Equal(fmt.Sprintf("only domain name: %s provided, expected exactly one domain, got %d", dummies.Domain.Name, 2)))
+			gomega.Ω(err).ShouldNot(gomega.Succeed())
+			gomega.Ω(err.Error()).Should(gomega.Equal(fmt.Sprintf("only domain name: %s provided, expected exactly one domain, got %d", dummies.Domain.Name, 2)))
 		})
 	})
 
-	Context("Get Account in CloudStack", func() {
-		It("search for account in CloudStack", func() {
+	ginkgo.Context("Get Account in CloudStack", func() {
+		ginkgo.It("search for account in CloudStack", func() {
 			dsp := &csapi.ListDomainsParams{}
 			asp := &csapi.ListAccountsParams{}
 			ds.EXPECT().NewListDomainsParams().Return(dsp)
@@ -142,11 +142,11 @@ var _ = Describe("User Credentials", func() {
 				Name: dummies.AccountName,
 			}}}, nil)
 
-			Ω(client.ResolveAccount(&dummies.Account)).Should(Succeed())
+			gomega.Ω(client.ResolveAccount(&dummies.Account)).Should(gomega.Succeed())
 
 		})
 
-		It("no account found in CloudStack for the provided Account name", func() {
+		ginkgo.It("no account found in CloudStack for the provided Account name", func() {
 			dsp := &csapi.ListDomainsParams{}
 			asp := &csapi.ListAccountsParams{}
 			ds.EXPECT().NewListDomainsParams().Return(dsp)
@@ -158,11 +158,11 @@ var _ = Describe("User Credentials", func() {
 			as.EXPECT().ListAccounts(asp).Return(&csapi.ListAccountsResponse{Count: 0, Accounts: []*csapi.Account{}}, nil)
 
 			err := client.ResolveAccount(&dummies.Account)
-			Ω(err).ShouldNot(Succeed())
-			Ω(err.Error()).Should(ContainSubstring("could not find account"))
+			gomega.Ω(err).ShouldNot(gomega.Succeed())
+			gomega.Ω(err.Error()).Should(gomega.ContainSubstring("could not find account"))
 		})
 
-		It("More than one account found in the provided domain and account name", func() {
+		ginkgo.It("More than one account found in the provided domain and account name", func() {
 			dsp := &csapi.ListDomainsParams{}
 			asp := &csapi.ListAccountsParams{}
 			ds.EXPECT().NewListDomainsParams().Return(dsp)
@@ -174,11 +174,11 @@ var _ = Describe("User Credentials", func() {
 			as.EXPECT().ListAccounts(asp).Return(&csapi.ListAccountsResponse{Count: 2, Accounts: []*csapi.Account{}}, nil)
 
 			err := client.ResolveAccount(&dummies.Account)
-			Ω(err).ShouldNot(Succeed())
-			Ω(err.Error()).Should(ContainSubstring("expected 1 Account with account name"))
+			gomega.Ω(err).ShouldNot(gomega.Succeed())
+			gomega.Ω(err.Error()).Should(gomega.ContainSubstring("expected 1 Account with account name"))
 		})
 
-		It("fails to list accounts", func() {
+		ginkgo.It("fails to list accounts", func() {
 			dsp := &csapi.ListDomainsParams{}
 			asp := &csapi.ListAccountsParams{}
 			ds.EXPECT().NewListDomainsParams().Return(dsp)
@@ -189,16 +189,16 @@ var _ = Describe("User Credentials", func() {
 			as.EXPECT().NewListAccountsParams().Return(asp)
 			as.EXPECT().ListAccounts(asp).Return(nil, fakeError)
 
-			Ω(client.ResolveAccount(&dummies.Account)).ShouldNot(Succeed())
+			gomega.Ω(client.ResolveAccount(&dummies.Account)).ShouldNot(gomega.Succeed())
 		})
 	})
 
-	Context("Get User from CloudStack", func() {
-		BeforeEach(func() {
+	ginkgo.Context("Get User from CloudStack", func() {
+		ginkgo.BeforeEach(func() {
 			dummies.SetDummyUserVars()
 		})
 
-		It("search for user in CloudStack", func() {
+		ginkgo.It("search for user in CloudStack", func() {
 			dsp := &csapi.ListDomainsParams{}
 			asp := &csapi.ListAccountsParams{}
 			usp := &csapi.ListUsersParams{}
@@ -221,10 +221,10 @@ var _ = Describe("User Credentials", func() {
 				}},
 			}, nil)
 
-			Ω(client.ResolveUser(&dummies.User)).Should(Succeed())
+			gomega.Ω(client.ResolveUser(&dummies.User)).Should(gomega.Succeed())
 		})
 
-		It("search for user fails while resolving account in CloudStack", func() {
+		ginkgo.It("search for user fails while resolving account in CloudStack", func() {
 			dsp := &csapi.ListDomainsParams{}
 			asp := &csapi.ListAccountsParams{}
 			ds.EXPECT().NewListDomainsParams().Return(dsp)
@@ -236,11 +236,11 @@ var _ = Describe("User Credentials", func() {
 			as.EXPECT().ListAccounts(asp).Return(nil, fakeError)
 
 			err := client.ResolveUser(&dummies.User)
-			Ω(err).ShouldNot(Succeed())
-			Ω(err.Error()).Should(ContainSubstring("resolving account"))
+			gomega.Ω(err).ShouldNot(gomega.Succeed())
+			gomega.Ω(err.Error()).Should(gomega.ContainSubstring("resolving account"))
 		})
 
-		It("search for user in CloudStack fails", func() {
+		ginkgo.It("search for user in CloudStack fails", func() {
 			dsp := &csapi.ListDomainsParams{}
 			asp := &csapi.ListAccountsParams{}
 			usp := &csapi.ListUsersParams{}
@@ -257,10 +257,10 @@ var _ = Describe("User Credentials", func() {
 			us.EXPECT().NewListUsersParams().Return(usp)
 			us.EXPECT().ListUsers(usp).Return(nil, fakeError)
 
-			Ω(client.ResolveUser(&dummies.User)).ShouldNot(Succeed())
+			gomega.Ω(client.ResolveUser(&dummies.User)).ShouldNot(gomega.Succeed())
 		})
 
-		It("search for user in CloudStack results in more than one user", func() {
+		ginkgo.It("search for user in CloudStack results in more than one user", func() {
 			dsp := &csapi.ListDomainsParams{}
 			asp := &csapi.ListAccountsParams{}
 			usp := &csapi.ListUsersParams{}
@@ -281,12 +281,12 @@ var _ = Describe("User Credentials", func() {
 			}, nil)
 
 			err := client.ResolveUser(&dummies.User)
-			Ω(err).ShouldNot(Succeed())
-			Ω(err.Error()).Should(ContainSubstring("expected 1 User with username"))
+			gomega.Ω(err).ShouldNot(gomega.Succeed())
+			gomega.Ω(err.Error()).Should(gomega.ContainSubstring("expected 1 User with username"))
 		})
 	})
 
-	Context("Get user keys in CloudStack", func() {
+	ginkgo.Context("Get user keys in CloudStack", func() {
 		initialCalls := func() {
 			dsp := &csapi.ListDomainsParams{}
 			asp := &csapi.ListAccountsParams{}
@@ -303,7 +303,7 @@ var _ = Describe("User Credentials", func() {
 			}}}, nil)
 		}
 
-		It("get user keys", func() {
+		ginkgo.It("get user keys", func() {
 			initialCalls()
 			usp := &csapi.ListUsersParams{}
 			ukp := &csapi.GetUserKeysParams{}
@@ -321,10 +321,10 @@ var _ = Describe("User Credentials", func() {
 				Secretkey: dummies.SecretKey,
 			}, nil)
 
-			Ω(client.ResolveUserKeys(&dummies.User)).Should(Succeed())
+			gomega.Ω(client.ResolveUserKeys(&dummies.User)).Should(gomega.Succeed())
 		})
 
-		It("get user keys fils when resolving user", func() {
+		ginkgo.It("get user keys fils when resolving user", func() {
 			initialCalls()
 			usp := &csapi.ListUsersParams{}
 
@@ -332,12 +332,12 @@ var _ = Describe("User Credentials", func() {
 			us.EXPECT().ListUsers(usp).Return(nil, fakeError)
 
 			err := client.ResolveUserKeys(&dummies.User)
-			Ω(err).ShouldNot(Succeed())
-			Ω(err.Error()).Should(ContainSubstring("error encountered when resolving user details"))
+			gomega.Ω(err).ShouldNot(gomega.Succeed())
+			gomega.Ω(err.Error()).Should(gomega.ContainSubstring("error encountered when resolving user details"))
 
 		})
 
-		It("get user keys fils when resolving user keys", func() {
+		ginkgo.It("get user keys fils when resolving user keys", func() {
 			initialCalls()
 			usp := &csapi.ListUsersParams{}
 			ukp := &csapi.GetUserKeysParams{}
@@ -354,13 +354,13 @@ var _ = Describe("User Credentials", func() {
 			us.EXPECT().GetUserKeys(ukp).Return(nil, fakeError)
 
 			err := client.ResolveUserKeys(&dummies.User)
-			Ω(err).ShouldNot(Succeed())
-			Ω(err.Error()).Should(ContainSubstring("error encountered when resolving user api keys"))
+			gomega.Ω(err).ShouldNot(gomega.Succeed())
+			gomega.Ω(err.Error()).Should(gomega.ContainSubstring("error encountered when resolving user api keys"))
 		})
 	})
 
-	Context("Get user with keys", func() {
-		BeforeEach(func() {
+	ginkgo.Context("Get user with keys", func() {
+		ginkgo.BeforeEach(func() {
 			dummies.SetDummyUserVars()
 		})
 
@@ -372,7 +372,7 @@ var _ = Describe("User Credentials", func() {
 				Path: "ROOT",
 			}}}, nil)
 		}
-		It("get first user for given account and domain", func() {
+		ginkgo.It("get first user for given account and domain", func() {
 			initialCalls()
 			initialCalls()
 			asp := &csapi.ListAccountsParams{}
@@ -399,22 +399,22 @@ var _ = Describe("User Credentials", func() {
 			}, nil)
 
 			result, err := client.GetUserWithKeys(&dummies.User)
-			Ω(err).Should(Succeed())
-			Ω(result).Should(BeTrue())
+			gomega.Ω(err).Should(gomega.Succeed())
+			gomega.Ω(result).Should(gomega.BeTrue())
 		})
 
-		It("fails to resolve accout", func() {
+		ginkgo.It("fails to resolve accout", func() {
 			initialCalls()
 			asp := &csapi.ListAccountsParams{}
 			as.EXPECT().NewListAccountsParams().Return(asp)
 			as.EXPECT().ListAccounts(asp).Return(nil, fakeError)
 
 			result, err := client.GetUserWithKeys(&dummies.User)
-			Ω(err.Error()).Should(ContainSubstring(fmt.Sprintf("resolving account %s details", dummies.User.Account.Name)))
-			Ω(result).Should(BeFalse())
+			gomega.Ω(err.Error()).Should(gomega.ContainSubstring(fmt.Sprintf("resolving account %s details", dummies.User.Account.Name)))
+			gomega.Ω(result).Should(gomega.BeFalse())
 		})
 
-		It("fails to resolve accout", func() {
+		ginkgo.It("fails to resolve accout", func() {
 			initialCalls()
 			asp := &csapi.ListAccountsParams{}
 			usp := &csapi.ListUsersParams{}
@@ -428,17 +428,17 @@ var _ = Describe("User Credentials", func() {
 			us.EXPECT().ListUsers(usp).Return(nil, fakeError)
 
 			result, err := client.GetUserWithKeys(&dummies.User)
-			Ω(err).ShouldNot(Succeed())
-			Ω(result).Should(BeFalse())
+			gomega.Ω(err).ShouldNot(gomega.Succeed())
+			gomega.Ω(result).Should(gomega.BeFalse())
 		})
 	})
 
-	Context("UserCred Integ Tests", Label("integ"), func() {
+	ginkgo.Context("UserCred Integ Tests", ginkgo.Label("integ"), func() {
 		var domain cloud.Domain
 		var account cloud.Account
 		var user cloud.User
 
-		BeforeEach(func() {
+		ginkgo.BeforeEach(func() {
 			client = realCloudClient
 
 			domain = cloud.Domain{Path: testDomainPath}
@@ -446,43 +446,43 @@ var _ = Describe("User Credentials", func() {
 			user = cloud.User{Name: helpers.TempUserName, Account: account}
 		})
 
-		It("can resolve a domain from the path", func() {
-			Ω(client.ResolveDomain(&domain)).Should(Succeed())
-			Ω(domain.ID).ShouldNot(BeEmpty())
+		ginkgo.It("can resolve a domain from the path", func() {
+			gomega.Ω(client.ResolveDomain(&domain)).Should(gomega.Succeed())
+			gomega.Ω(domain.ID).ShouldNot(gomega.BeEmpty())
 		})
 
-		It("can resolve an account from the domain path and account name", func() {
-			Ω(client.ResolveAccount(&account)).Should(Succeed())
-			Ω(account.ID).ShouldNot(BeEmpty())
+		ginkgo.It("can resolve an account from the domain path and account name", func() {
+			gomega.Ω(client.ResolveAccount(&account)).Should(gomega.Succeed())
+			gomega.Ω(account.ID).ShouldNot(gomega.BeEmpty())
 		})
 
-		It("can resolve a user from the domain path, account name, and user name", func() {
-			Ω(client.ResolveUser(&user)).Should(Succeed())
-			Ω(user.ID).ShouldNot(BeEmpty())
+		ginkgo.It("can resolve a user from the domain path, account name, and user name", func() {
+			gomega.Ω(client.ResolveUser(&user)).Should(gomega.Succeed())
+			gomega.Ω(user.ID).ShouldNot(gomega.BeEmpty())
 		})
 
-		It("can get sub-domain user's credentials", func() {
-			Ω(client.ResolveUserKeys(&user)).Should(Succeed())
+		ginkgo.It("can get sub-domain user's credentials", func() {
+			gomega.Ω(client.ResolveUserKeys(&user)).Should(gomega.Succeed())
 
-			Ω(user.APIKey).ShouldNot(BeEmpty())
-			Ω(user.SecretKey).ShouldNot(BeEmpty())
+			gomega.Ω(user.APIKey).ShouldNot(gomega.BeEmpty())
+			gomega.Ω(user.SecretKey).ShouldNot(gomega.BeEmpty())
 		})
 
-		It("can get an arbitrary user with keys from domain and account specifications alone", func() {
+		ginkgo.It("can get an arbitrary user with keys from domain and account specifications alone", func() {
 			found, err := client.GetUserWithKeys(&user)
-			Ω(err).ShouldNot(HaveOccurred())
-			Ω(found).Should(BeTrue())
-			Ω(user.APIKey).ShouldNot(BeEmpty())
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Ω(found).Should(gomega.BeTrue())
+			gomega.Ω(user.APIKey).ShouldNot(gomega.BeEmpty())
 		})
 
-		It("can get create a new client as another user", func() {
+		ginkgo.It("can get create a new client as another user", func() {
 			found, err := client.GetUserWithKeys(&user)
-			Ω(err).ShouldNot(HaveOccurred())
-			Ω(found).Should(BeTrue())
-			Ω(user.APIKey).ShouldNot(BeEmpty())
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Ω(found).Should(gomega.BeTrue())
+			gomega.Ω(user.APIKey).ShouldNot(gomega.BeEmpty())
 			newClient, err := client.NewClientInDomainAndAccount(user.Account.Domain.Name, user.Account.Name, "")
-			Ω(err).ShouldNot(HaveOccurred())
-			Ω(newClient).ShouldNot(BeNil())
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Ω(newClient).ShouldNot(gomega.BeNil())
 		})
 	})
 })

--- a/pkg/cloud/zone.go
+++ b/pkg/cloud/zone.go
@@ -40,15 +40,15 @@ func (c *client) ResolveZone(zSpec *infrav1.CloudStackZoneSpec) (retErr error) {
 		zSpec.ID = zoneID
 	}
 
-	if resp, count, err := c.cs.Zone.GetZoneByID(zSpec.ID); err != nil {
+	resp, count, err := c.cs.Zone.GetZoneByID(zSpec.ID)
+	if err != nil {
 		c.customMetrics.EvaluateErrorAndIncrementAcsReconciliationErrorCounter(err)
 		return multierror.Append(retErr, errors.Wrapf(err, "could not get Zone by ID %v", zSpec.ID))
 	} else if count != 1 {
 		return multierror.Append(retErr, errors.Errorf(
 			"expected 1 Zone with UUID %s, but got %d", zSpec.ID, count))
-	} else {
-		zSpec.Name = resp.Name
 	}
+	zSpec.Name = resp.Name
 
 	return nil
 }

--- a/pkg/cloud/zone_test.go
+++ b/pkg/cloud/zone_test.go
@@ -21,14 +21,14 @@ import (
 
 	csapi "github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 	dummies "sigs.k8s.io/cluster-api-provider-cloudstack/test/dummies/v1beta3"
 )
 
-var _ = Describe("Zone", func() {
+var _ = ginkgo.Describe("Zone", func() {
 	const (
 		errorMessage = "Error"
 	)
@@ -42,8 +42,8 @@ var _ = Describe("Zone", func() {
 		ns         *csapi.MockNetworkServiceIface
 	)
 
-	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
+	ginkgo.BeforeEach(func() {
+		mockCtrl = gomock.NewController(ginkgo.GinkgoT())
 		mockClient = csapi.NewMockClient(mockCtrl)
 		zs = mockClient.Zone.(*csapi.MockZoneServiceIface)
 		ns = mockClient.Network.(*csapi.MockNetworkServiceIface)
@@ -51,65 +51,65 @@ var _ = Describe("Zone", func() {
 		dummies.SetDummyVars()
 	})
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 		mockCtrl.Finish()
 	})
 
-	Context("an existing abstract dummies.CSCluster", func() {
-		It("handles zone not found.", func() {
+	ginkgo.Context("an existing abstract dummies.CSCluster", func() {
+		ginkgo.It("handles zone not found.", func() {
 			expectedErr := fmt.Errorf("Not found")
 			zs.EXPECT().GetZoneID(dummies.Zone1.Name).Return("", -1, expectedErr)
 			zs.EXPECT().GetZoneByID(dummies.Zone1.ID).Return(nil, -1, expectedErr)
 
 			err := client.ResolveZone(&dummies.CSFailureDomain1.Spec.Zone)
-			Expect(errors.Cause(err)).To(MatchError(expectedErr))
+			gomega.Expect(errors.Cause(err)).To(gomega.MatchError(expectedErr))
 		})
 
-		It("handles multiple zone IDs returned", func() {
+		ginkgo.It("handles multiple zone IDs returned", func() {
 			zs.EXPECT().GetZoneID(dummies.Zone1.Name).Return(dummies.Zone1.ID, 2, nil)
 			zs.EXPECT().GetZoneByID(dummies.Zone1.ID).Return(nil, -1, fmt.Errorf("Not found"))
 
-			Ω(client.ResolveZone(&dummies.CSFailureDomain1.Spec.Zone)).Should(MatchError(And(
-				ContainSubstring("expected 1 Zone with name "+dummies.Zone1.Name+", but got 2"),
-				ContainSubstring("could not get Zone by ID "+dummies.Zone1.ID+": Not found"))))
+			gomega.Ω(client.ResolveZone(&dummies.CSFailureDomain1.Spec.Zone)).Should(gomega.MatchError(gomega.And(
+				gomega.ContainSubstring("expected 1 Zone with name "+dummies.Zone1.Name+", but got 2"),
+				gomega.ContainSubstring("could not get Zone by ID "+dummies.Zone1.ID+": Not found"))))
 		})
 
-		It("returns multiple zones for a given id", func() {
+		ginkgo.It("returns multiple zones for a given id", func() {
 			zs.EXPECT().GetZoneID(dummies.Zone1.Name).Return(dummies.Zone1.ID, 2, nil)
 			zs.EXPECT().GetZoneByID(dummies.Zone1.ID).Return(&csapi.Zone{}, 2, nil)
 
-			Ω(client.ResolveZone(&dummies.CSFailureDomain1.Spec.Zone).Error()).
-				Should(ContainSubstring("expected 1 Zone with name " + dummies.Zone1.Name + ", but got 2"))
+			gomega.Ω(client.ResolveZone(&dummies.CSFailureDomain1.Spec.Zone).Error()).
+				Should(gomega.ContainSubstring("expected 1 Zone with name " + dummies.Zone1.Name + ", but got 2"))
 		})
 	})
 
-	Context("Resolve network for zone", func() {
-		It("get network by name specfied in zone spec", func() {
+	ginkgo.Context("Resolve network for zone", func() {
+		ginkgo.It("get network by name specfied in zone spec", func() {
 			ns.EXPECT().GetNetworkByName(dummies.Zone1.Network.Name, gomock.Any()).Return(&csapi.Network{}, 1, nil)
 
-			Ω(client.ResolveNetworkForZone(&dummies.CSFailureDomain1.Spec.Zone)).Should(Succeed())
+			gomega.Ω(client.ResolveNetworkForZone(&dummies.CSFailureDomain1.Spec.Zone)).Should(gomega.Succeed())
 		})
 
-		It("get network by name specfied in zone spec returns > 1 network", func() {
+		ginkgo.It("get network by name specfied in zone spec returns > 1 network", func() {
 			ns.EXPECT().GetNetworkByName(dummies.Zone2.Network.Name, gomock.Any()).Return(&csapi.Network{}, 2, nil)
 			ns.EXPECT().GetNetworkByID(dummies.Zone2.Network.ID, gomock.Any()).Return(&csapi.Network{}, 2, nil)
 
-			Ω(client.ResolveNetworkForZone(&dummies.CSFailureDomain2.Spec.Zone)).Should(MatchError(And(
-				ContainSubstring(fmt.Sprintf("expected 1 Network with name %s, but got %d", dummies.Zone2.Network.Name, 2)),
-				ContainSubstring(fmt.Sprintf("expected 1 Network with UUID %v, but got %d", dummies.Zone2.Network.ID, 2)))))
+			gomega.Ω(client.ResolveNetworkForZone(&dummies.CSFailureDomain2.Spec.Zone)).Should(gomega.MatchError(gomega.And(
+				gomega.ContainSubstring(fmt.Sprintf("expected 1 Network with name %s, but got %d", dummies.Zone2.Network.Name, 2)),
+				gomega.ContainSubstring(fmt.Sprintf("expected 1 Network with UUID %v, but got %d", dummies.Zone2.Network.ID, 2)))))
 		})
 
-		It("get network by id specfied in zone spec", func() {
+		ginkgo.It("get network by id specfied in zone spec", func() {
 			ns.EXPECT().GetNetworkByName(dummies.Zone2.Network.Name, gomock.Any()).Return(nil, -1, fakeError)
 			ns.EXPECT().GetNetworkByID(dummies.Zone2.Network.ID, gomock.Any()).Return(&csapi.Network{}, 1, nil)
-			Ω(client.ResolveNetworkForZone(&dummies.CSFailureDomain2.Spec.Zone)).Should(Succeed())
+			gomega.Ω(client.ResolveNetworkForZone(&dummies.CSFailureDomain2.Spec.Zone)).Should(gomega.Succeed())
 		})
 
-		It("get network by id fails", func() {
+		ginkgo.It("get network by id fails", func() {
 			ns.EXPECT().GetNetworkByName(dummies.Zone2.Network.Name, gomock.Any()).Return(nil, -1, fakeError)
 			ns.EXPECT().GetNetworkByID(dummies.Zone2.Network.ID, gomock.Any()).Return(nil, -1, fakeError)
 
-			Ω(client.ResolveNetworkForZone(&dummies.CSFailureDomain2.Spec.Zone).Error()).Should(ContainSubstring(fmt.Sprintf("could not get Network by ID %s", dummies.Zone2.Network.ID)))
+			gomega.Ω(client.ResolveNetworkForZone(&dummies.CSFailureDomain2.Spec.Zone).Error()).Should(gomega.ContainSubstring(fmt.Sprintf("could not get Network by ID %s", dummies.Zone2.Network.ID)))
 		})
 	})
 })

--- a/pkg/webhookutil/webhook_validators.go
+++ b/pkg/webhookutil/webhook_validators.go
@@ -38,28 +38,28 @@ func EnsureAtLeastOneFieldExists(value1 string, value2 string, name string, allE
 	return allErrs
 }
 
-func EnsureEqualStrings(new string, old string, name string, allErrs field.ErrorList) field.ErrorList {
-	if new != old {
+func EnsureEqualStrings(newString string, oldString string, name string, allErrs field.ErrorList) field.ErrorList {
+	if newString != oldString {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", name), name))
 	}
 	return allErrs
 }
 
-func EnsureIntFieldsAreNotNegative(new int64, name string, allErrs field.ErrorList) field.ErrorList {
-	if new < 0 {
+func EnsureIntFieldsAreNotNegative(newInt int64, name string, allErrs field.ErrorList) field.ErrorList {
+	if newInt < 0 {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", name), name))
 	}
 	return allErrs
 }
 
-func EnsureEqualMapStringString(new *map[string]string, old *map[string]string, name string, allErrs field.ErrorList) field.ErrorList {
-	if old == nil && new == nil {
+func EnsureEqualMapStringString(newMap *map[string]string, oldMap *map[string]string, name string, allErrs field.ErrorList) field.ErrorList {
+	if oldMap == nil && newMap == nil {
 		return allErrs
 	}
-	if new == nil || old == nil {
+	if newMap == nil || oldMap == nil {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", name), name))
 	}
-	if !reflect.DeepEqual(old, new) {
+	if !reflect.DeepEqual(oldMap, newMap) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", name), name))
 	}
 	return allErrs

--- a/test/helpers/suite_test.go
+++ b/test/helpers/suite_test.go
@@ -3,11 +3,11 @@ package helpers_test
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 )
 
 func TestCloud(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Cloud Suite")
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Cloud Suite")
 }

--- a/test/helpers/user_test.go
+++ b/test/helpers/user_test.go
@@ -17,110 +17,110 @@ limitations under the License.
 package helpers_test
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/pkg/cloud"
 	"sigs.k8s.io/cluster-api-provider-cloudstack/test/helpers"
 )
 
-var _ = Describe("Test helper methods", func() {
+var _ = ginkgo.Describe("Test helper methods", func() {
 	csClient, err := helpers.NewCSClient()
-	Ω(err).ShouldNot(HaveOccurred())
+	gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
 
 	// Get the root domain's ID.
 	rootDomainID, err, found := helpers.GetDomainByPath(csClient, "ROOT/")
-	Ω(err).ShouldNot(HaveOccurred())
-	Ω(rootDomainID).ShouldNot(BeEmpty())
-	Ω(found).Should(BeTrue())
+	gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+	gomega.Ω(rootDomainID).ShouldNot(gomega.BeEmpty())
+	gomega.Ω(found).Should(gomega.BeTrue())
 
-	AfterEach(func() {
+	ginkgo.AfterEach(func() {
 		for _, path := range []string{"ROOT/someNewDomain", "ROOT/blah"} {
 			// Delete any created domains.
 			id, err, found := helpers.GetDomainByPath(csClient, path)
-			Ω(err).ShouldNot(HaveOccurred())
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
 			if found {
-				Ω(helpers.DeleteDomain(csClient, id)).Should(Succeed())
+				gomega.Ω(helpers.DeleteDomain(csClient, id)).Should(gomega.Succeed())
 			}
 		}
 	})
 
-	Context("Domain Creation and Deletion.", func() {
-		It("Can get the ROOT domain's ID.", func() {
+	ginkgo.Context("Domain Creation and Deletion.", func() {
+		ginkgo.It("Can get the ROOT domain's ID.", func() {
 			id, err, found := helpers.GetDomainByPath(csClient, "ROOT/")
-			Ω(err).ShouldNot(HaveOccurred())
-			Ω(id).ShouldNot(BeEmpty())
-			Ω(found).Should(BeTrue())
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Ω(id).ShouldNot(gomega.BeEmpty())
+			gomega.Ω(found).Should(gomega.BeTrue())
 		})
 
-		It("Doesn't error when unable to get a domain's ID.", func() {
+		ginkgo.It("Doesn't error when unable to get a domain's ID.", func() {
 			id, err, found := helpers.GetDomainByPath(csClient, "ROOT/blahnotpresent")
-			Ω(err).ShouldNot(HaveOccurred())
-			Ω(found).Should(BeFalse())
-			Ω(id).Should(BeEmpty())
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
+			gomega.Ω(found).Should(gomega.BeFalse())
+			gomega.Ω(id).Should(gomega.BeEmpty())
 		})
 
-		It("Can create a domain under a parent domain.", func() {
+		ginkgo.It("Can create a domain under a parent domain.", func() {
 			id, err := helpers.CreateDomainUnderParent(csClient, rootDomainID, "someNewDomain")
-			Ω(id).ShouldNot(BeEmpty())
-			Ω(err).ShouldNot(HaveOccurred())
+			gomega.Ω(id).ShouldNot(gomega.BeEmpty())
+			gomega.Ω(err).ShouldNot(gomega.HaveOccurred())
 		})
 
-		It("Returns an appropriate error when the domain already exists.", func() {
+		ginkgo.It("Returns an appropriate error when the domain already exists.", func() {
 			someDomain := &cloud.Domain{Name: "blah", Path: "blah"}
-			Ω(helpers.GetOrCreateDomain(csClient, someDomain)).Should(Succeed())
-			Ω(someDomain.Name).Should(Equal("blah"))
-			Ω(someDomain.Path).Should(Equal("ROOT/blah"))
-			Ω(someDomain.ID).ShouldNot(BeEmpty())
+			gomega.Ω(helpers.GetOrCreateDomain(csClient, someDomain)).Should(gomega.Succeed())
+			gomega.Ω(someDomain.Name).Should(gomega.Equal("blah"))
+			gomega.Ω(someDomain.Path).Should(gomega.Equal("ROOT/blah"))
+			gomega.Ω(someDomain.ID).ShouldNot(gomega.BeEmpty())
 			_, err = helpers.CreateDomainUnderParent(csClient, rootDomainID, "blah")
-			Ω(err).Should(HaveOccurred())
-			Ω(err.Error()).Should(ContainSubstring("already exists"))
+			gomega.Ω(err).Should(gomega.HaveOccurred())
+			gomega.Ω(err.Error()).Should(gomega.ContainSubstring("already exists"))
 		})
 
-		It("Doesn't error if the domain already exists.", func() {
+		ginkgo.It("Doesn't error if the domain already exists.", func() {
 			someDomain := &cloud.Domain{Name: "blah", Path: "blah"}
-			Ω(helpers.GetOrCreateDomain(csClient, someDomain)).Should(Succeed())
-			Ω(someDomain.Name).Should(Equal("blah"))
-			Ω(someDomain.Path).Should(Equal("ROOT/blah"))
-			Ω(someDomain.ID).ShouldNot(BeEmpty())
+			gomega.Ω(helpers.GetOrCreateDomain(csClient, someDomain)).Should(gomega.Succeed())
+			gomega.Ω(someDomain.Name).Should(gomega.Equal("blah"))
+			gomega.Ω(someDomain.Path).Should(gomega.Equal("ROOT/blah"))
+			gomega.Ω(someDomain.ID).ShouldNot(gomega.BeEmpty())
 
-			Ω(helpers.GetOrCreateDomain(csClient, someDomain)).Should(Succeed())
-			Ω(someDomain.Name).Should(Equal("blah"))
-			Ω(someDomain.Path).Should(Equal("ROOT/blah"))
-			Ω(someDomain.ID).ShouldNot(BeEmpty())
+			gomega.Ω(helpers.GetOrCreateDomain(csClient, someDomain)).Should(gomega.Succeed())
+			gomega.Ω(someDomain.Name).Should(gomega.Equal("blah"))
+			gomega.Ω(someDomain.Path).Should(gomega.Equal("ROOT/blah"))
+			gomega.Ω(someDomain.ID).ShouldNot(gomega.BeEmpty())
 		})
 
-		It("Can create a wholly new multi-level sub-domain path.", func() {
+		ginkgo.It("Can create a wholly new multi-level sub-domain path.", func() {
 			someDomain := &cloud.Domain{Name: "tooBlah", Path: "ROOT/someNewDomain/tooBlah"}
-			Ω(helpers.GetOrCreateDomain(csClient, someDomain)).Should(Succeed())
-			Ω(someDomain.Name).Should(Equal("tooBlah"))
-			Ω(someDomain.Path).Should(Equal("ROOT/someNewDomain/tooBlah"))
-			Ω(someDomain.ID).ShouldNot(BeEmpty())
+			gomega.Ω(helpers.GetOrCreateDomain(csClient, someDomain)).Should(gomega.Succeed())
+			gomega.Ω(someDomain.Name).Should(gomega.Equal("tooBlah"))
+			gomega.Ω(someDomain.Path).Should(gomega.Equal("ROOT/someNewDomain/tooBlah"))
+			gomega.Ω(someDomain.ID).ShouldNot(gomega.BeEmpty())
 		})
 	})
 
-	Context("Account Creation.", func() {
-		It("Can create a new account in a new domain.", func() {
+	ginkgo.Context("Account Creation.", func() {
+		ginkgo.It("Can create a new account in a new domain.", func() {
 			domain := cloud.Domain{Path: "ROOT/someNewDomain/tooBlah"}
 			account := cloud.Account{Name: "TempTestAccount", Domain: domain}
-			Ω(helpers.GetOrCreateAccount(csClient, &account)).Should(Succeed())
+			gomega.Ω(helpers.GetOrCreateAccount(csClient, &account)).Should(gomega.Succeed())
 		})
 		// already exists
-		It("Doesn't fail if the account already exists.", func() {
+		ginkgo.It("Doesn't fail if the account already exists.", func() {
 			domain := cloud.Domain{Path: "ROOT/someNewDomain/tooBlah"}
 			account := cloud.Account{Name: "TempTestAccount", Domain: domain}
-			Ω(helpers.GetOrCreateAccount(csClient, &account)).Should(Succeed())
-			Ω(helpers.GetOrCreateAccount(csClient, &account)).Should(Succeed())
+			gomega.Ω(helpers.GetOrCreateAccount(csClient, &account)).Should(gomega.Succeed())
+			gomega.Ω(helpers.GetOrCreateAccount(csClient, &account)).Should(gomega.Succeed())
 		})
 	})
 
-	Context("User Creation w/Keys.", func() {
-		It("Can create a new user with keys.", func() {
+	ginkgo.Context("User Creation w/Keys.", func() {
+		ginkgo.It("Can create a new user with keys.", func() {
 			domain := cloud.Domain{Path: "ROOT/someNewDomain/tooBlah"}
 			account := cloud.Account{Name: "TempTestAccount", Domain: domain}
 			user := cloud.User{Account: account}
-			Ω(helpers.GetOrCreateUserWithKey(csClient, &user)).Should(Succeed())
-			Ω(user.ID).ShouldNot(BeEmpty())
-			Ω(user.APIKey).ShouldNot(BeEmpty())
+			gomega.Ω(helpers.GetOrCreateUserWithKey(csClient, &user)).Should(gomega.Succeed())
+			gomega.Ω(user.ID).ShouldNot(gomega.BeEmpty())
+			gomega.Ω(user.APIKey).ShouldNot(gomega.BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes the following lint issues discovered using golangci-lint:
1. **dot-imports:** should not use dot imports
2. **unused-parameter:** Remove unused arguments in methods
3. **indent-error-flow:** if block ends with a return statement, so drop this else and outdent its block (move short variable  declaration to its own line if necessary)
4. **redefines-builtin-id:** redefinition of the built-in function new

*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->