### PR TITLE
Fixup cache key for projects

### DIFF
--- a/pkg/cloud/client.go
+++ b/pkg/cloud/client.go
@@ -160,7 +160,7 @@ func NewClientFromConf(conf Config, clientConfig *corev1.ConfigMap, project stri
 		clientCache = newClientCache(clientConfig)
 	}
 
-	clientCacheKey := generateClientCacheKey(conf)
+	clientCacheKey := generateClientCacheKey(conf, project)
 	if item := clientCache.Get(clientCacheKey); item != nil {
 		return item.Value(), nil
 	}
@@ -252,8 +252,8 @@ func NewClientFromCSAPIClient(cs *cloudstack.CloudStackClient, user *User) Clien
 }
 
 // generateClientCacheKey generates a cache key from a Config
-func generateClientCacheKey(conf Config) string {
-	return fmt.Sprintf("%+v", conf)
+func generateClientCacheKey(conf Config, project string) string {
+	return fmt.Sprintf("%s-%+v", project, conf)
 }
 
 // newClientCache returns a new instance of client cache


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This pull request includes changes to the `pkg/cloud/client.go` file to improve the client caching mechanism by incorporating the project identifier into the cache key generation.

Improvements to client caching:

* [`pkg/cloud/client.go`](diffhunk://#diff-3defac9b675c35c29aeb0bb70eebf83796a03545a82d4e4b22df627f57506c01L255-R256): Modified the `generateClientCacheKey` function to include the `project` parameter, ensuring that the cache key is unique per project.
* [`pkg/cloud/client.go`](diffhunk://#diff-3defac9b675c35c29aeb0bb70eebf83796a03545a82d4e4b22df627f57506c01L163-R163): Updated the `NewClientFromConf` function to pass the `project` parameter to the `generateClientCacheKey` function.


*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->