### PR TITLE
Fix: egress rules & tags check existing

### DIFF
--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -529,6 +529,7 @@ func autoConvert_v1beta3_CloudStackIsolatedNetworkStatus_To_v1beta1_CloudStackIs
 	out.PublicIPID = in.PublicIPID
 	out.LBRuleID = in.LBRuleID
 	// WARNING: in.RoutingMode requires manual conversion: does not exist in peer-type
+	// WARNING: in.FirewallRulesOpened requires manual conversion: does not exist in peer-type
 	out.Ready = in.Ready
 	return nil
 }

--- a/api/v1beta2/zz_generated.conversion.go
+++ b/api/v1beta2/zz_generated.conversion.go
@@ -838,6 +838,7 @@ func autoConvert_v1beta3_CloudStackIsolatedNetworkStatus_To_v1beta2_CloudStackIs
 	out.PublicIPID = in.PublicIPID
 	out.LBRuleID = in.LBRuleID
 	// WARNING: in.RoutingMode requires manual conversion: does not exist in peer-type
+	// WARNING: in.FirewallRulesOpened requires manual conversion: does not exist in peer-type
 	out.Ready = in.Ready
 	return nil
 }

--- a/api/v1beta3/cloudstackisolatednetwork_types.go
+++ b/api/v1beta3/cloudstackisolatednetwork_types.go
@@ -73,6 +73,9 @@ type CloudStackIsolatedNetworkStatus struct {
 	// Empty value means the network mode is NATTED, not ROUTED.
 	RoutingMode string `json:"routingMode,omitempty"`
 
+	// Firewall rules open status.
+	FirewallRulesOpened bool `json:"firewallRulesOpened,omitempty"`
+
 	// Ready indicates the readiness of this provider resource.
 	Ready bool `json:"ready"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_cloudstackisolatednetworks.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_cloudstackisolatednetworks.yaml
@@ -251,6 +251,9 @@ spec:
             description: CloudStackIsolatedNetworkStatus defines the observed state
               of CloudStackIsolatedNetwork
             properties:
+              firewallRulesOpened:
+                description: Firewall rules open status.
+                type: boolean
               loadBalancerRuleID:
                 description: The ID of the lb rule used to assign VMs to the lb.
                 type: string


### PR DESCRIPTION


*Issue #, if available:*

Currently this provider for `isolated_network` and `tags` do not properly check for existing egress rules or tags.  This causes errors to happen in Cloudstack Events constantly saying the egress rule or tag already exists


![image](https://github.com/user-attachments/assets/d1e6fe56-e4c0-489c-9386-bf46d73151e0)

In Cloudstack Management logs (egress rules):

> 2025-06-13 03:41:34,847 INFO  [c.c.a.ApiServer] (qtp1789718525-1648:ctx-1dcfb09c ctx-26114600 ctx-aaefd36d) (logid:fd19bc1e) There is already a firewall rule specified with protocol = udp and no ports
> com.cloud.exception.NetworkRuleConflictException: There is already a firewall rule specified with protocol = tcp and no ports
> 

In Cloudstack Management logs (tags):

> 2025-06-13 03:41:34,593 DEBUG [c.c.u.d.T.Transaction] (API-Job-Executor-90:ctx-29a27d87 job-503553 ctx-79468eac) (logid:ec70b352) Rolling back the transaction: Time = 5 Name =  API-Job-Executor-90; called by -TransactionLegacy.rollback:890-TransactionLegacy.removeUpTo:833-TransactionLegacy.close:657-TransactionContextInterceptor.invoke:36-ReflectiveMethodInvocation.proceed:175-ExposeInvocationInterceptor.invoke:97-ReflectiveMethodInvocation.proceed:186-JdkDynamicAopProxy.invoke:215-$Proxy42.persist:-1-TaggedResourceManagerImpl$1.doInTransactionWithoutResult:219-TransactionCallbackNoReturn.doInTransaction:25-Transaction$2.doInTransaction:50
> 2025-06-13 03:41:34,625 ERROR [c.c.a.ApiAsyncJobDispatcher] (API-Job-Executor-90:ctx-29a27d87 job-503553) (logid:ec70b352) Unexpected exception while executing org.apache.cloudstack.api.command.user.tag.CreateTagsCmd
> 2025-06-13 03:41:34,627 DEBUG [o.a.c.f.j.i.AsyncJobManagerImpl] (API-Job-Executor-90:ctx-29a27d87 job-503553) (logid:ec70b352) Complete async job-503553, jobStatus: FAILED, resultCode: 530, result: org.apache.cloudstack.api.response.ExceptionResponse/null/{"uuidList":[],"errorcode":"530","errortext":"tag CAPC_cluster_741e900a-4577-40af-a442-9d7ae411b3be already on Network with id 8d65f071-aca2-46cb-bcd7-c3c5538254d7"}
> 

*Description of changes:*

Updating `tags` and `isolated_network` to properly check for existing egress rules and tags and handle accordingly.

*Testing performed:*

Ran `docker-build` and `docker-push` and then updated my image version on the capc provider to use new image.  Observed that errors went away and that it still properly adds the egress rules and tags if removed and doesn't cause any errors in Cloudstack


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->