### PR TITLE
Deregister control plane VM from Kubernetes_API_Server LB rule on CloudStackMachine delete

### DIFF
--- a/controllers/cloudstackmachine_controller.go
+++ b/controllers/cloudstackmachine_controller.go
@@ -126,6 +126,7 @@ func (r *CloudStackMachineReconciliationRunner) Reconcile() (retRes ctrl.Result,
 		r.ConsiderAffinity,
 		r.GetOrCreateVMInstance,
 		r.RequeueIfInstanceNotRunning,
+		r.RemoveFromLBIfMachineDeleting,
 		r.AddToLBIfNeeded,
 		r.GetOrCreateMachineStateChecker,
 	)
@@ -292,8 +293,45 @@ func (r *CloudStackMachineReconciliationRunner) RequeueIfInstanceNotRunning() (r
 	return ctrl.Result{}, nil
 }
 
+// usesAPIServerLB reports whether the CloudStackMachine participates in the API server
+// load balancer rule: it is on a non-routed isolated network and has an InstanceID.
+// Caller is responsible for ensuring r.IsoNet is populated.
+func (r *CloudStackMachineReconciliationRunner) usesAPIServerLB() bool {
+	return r.FailureDomain.Spec.Zone.Network.Type == cloud.NetworkTypeIsolated &&
+		r.IsoNet.Spec.Name != "" &&
+		r.IsoNet.Status.RoutingMode == "" &&
+		r.ReconciliationSubject.Spec.InstanceID != nil
+}
+
+// RemoveFromLBIfMachineDeleting detaches the VM from the API server load balancer rule as soon
+// as the parent CAPI Machine is marked for deletion, before CAPI deletes the CloudStackMachine.
+// VM removal can take a while, and the CloudStack LB health check only marks the member offline
+// after some delay, so without this step API traffic keeps hitting the about-to-be-replaced
+// kube-apiserver throughout that window. RemoveFromLBIfNeeded (in ReconcileDelete) remains as a
+// safety net.
+func (r *CloudStackMachineReconciliationRunner) RemoveFromLBIfMachineDeleting() (retRes ctrl.Result, reterr error) {
+	if r.CAPIMachine == nil || r.CAPIMachine.DeletionTimestamp.IsZero() ||
+		!util.IsControlPlaneMachine(r.CAPIMachine) || !r.usesAPIServerLB() {
+		return ctrl.Result{}, nil
+	}
+
+	instanceID := *r.ReconciliationSubject.Spec.InstanceID
+	r.Log.Info("CAPI Machine is being deleted; detaching VM from API server load balancer rule",
+		"instance-id", instanceID, "lbRuleID", r.IsoNet.Status.LBRuleID, "capiMachine", r.CAPIMachine.Name)
+	if err := r.CSUser.RemoveVMFromLoadBalancerRule(r.IsoNet, instanceID); err != nil {
+		r.Log.Error(err, "Early LB removal failed", "instance-id", instanceID, "lbRuleID", r.IsoNet.Status.LBRuleID)
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
 // AddToLBIfNeeded adds instance to load balancer if it is a control plane in an isolated network.
 func (r *CloudStackMachineReconciliationRunner) AddToLBIfNeeded() (retRes ctrl.Result, reterr error) {
+	// Skip add when the parent Machine is being deleted; RemoveFromLBIfMachineDeleting just
+	// detached this VM and we don't want to re-add it in the same reconcile loop.
+	if r.CAPIMachine != nil && !r.CAPIMachine.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
 	if util.IsControlPlaneMachine(r.CAPIMachine) && r.FailureDomain.Spec.Zone.Network.Type == cloud.NetworkTypeIsolated {
 		if r.IsoNet.Spec.Name == "" {
 			return r.RequeueWithMessage("Could not get required Isolated Network for VM, requeueing.")
@@ -307,6 +345,36 @@ func (r *CloudStackMachineReconciliationRunner) AddToLBIfNeeded() (retRes ctrl.R
 				return ctrl.Result{}, err
 			}
 		}
+	}
+	return ctrl.Result{}, nil
+}
+
+// RemoveFromLBIfNeeded detaches the VM from the API server load balancer rule on the
+// CloudStackMachine delete path, before the VM itself is destroyed. The CAPI Machine is not
+// loaded on this path, so the control-plane check uses the MachineControlPlaneLabel on the
+// CloudStackMachine, and IsoNet is fetched here rather than relying on prior reconcile stages.
+func (r *CloudStackMachineReconciliationRunner) RemoveFromLBIfNeeded() (retRes ctrl.Result, reterr error) {
+	if _, ok := r.ReconciliationSubject.Labels[clusterv1.MachineControlPlaneLabel]; !ok {
+		return ctrl.Result{}, nil
+	}
+	if r.FailureDomain.Spec.Zone.Network.Type != cloud.NetworkTypeIsolated ||
+		r.ReconciliationSubject.Spec.InstanceID == nil {
+		return ctrl.Result{}, nil
+	}
+
+	if res, err := r.GetObjectByName(
+		r.IsoNetMetaName(r.FailureDomain.Spec.Zone.Network.Name), r.IsoNet,
+	)(); r.ShouldReturn(res, err) {
+		return res, err
+	}
+	if !r.usesAPIServerLB() {
+		return ctrl.Result{}, nil
+	}
+
+	instanceID := *r.ReconciliationSubject.Spec.InstanceID
+	r.Log.Info("Removing VM from API server load balancer rule", "instance-id", instanceID)
+	if err := r.CSUser.RemoveVMFromLoadBalancerRule(r.IsoNet, instanceID); err != nil {
+		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
 }
@@ -344,6 +412,12 @@ func (r *CloudStackMachineReconciliationRunner) ReconcileDelete() (retRes ctrl.R
 			return ctrl.Result{}, err
 		}
 	}
+
+	// Detach the VM from the API server LB rule before destroying it.
+	if res, err := r.RemoveFromLBIfNeeded(); r.ShouldReturn(res, err) {
+		return res, err
+	}
+
 	r.Recorder.Eventf(r.ReconciliationSubject, "Normal", "Deleting", CSMachineDeletionMessage, r.ReconciliationSubject.Name)
 	r.Log.Info("Deleting instance", "instance-id", r.ReconciliationSubject.Spec.InstanceID)
 	// Use CSClient instead of CSUser here to expunge as admin.
@@ -402,9 +476,10 @@ func (reconciler *CloudStackMachineReconciler) SetupWithManager(ctx context.Cont
 			),
 		)
 
-	// Watch CAPI machines for changes.
-	// Queues a reconcile request for owned CloudStackMachine on change.
-	// Used to update when bootstrap data becomes available.
+	// Watch CAPI machines and enqueue the owned CloudStackMachine on:
+	//   - Bootstrap.DataSecretName becoming set: VM creation can proceed.
+	//   - DeletionTimestamp becoming set: detach the VM from the API server LB rule early
+	//     (see RemoveFromLBIfMachineDeleting), before drain begins.
 	b = b.Watches(
 		&clusterv1.Machine{},
 		handler.EnqueueRequestsFromMapFunc(
@@ -415,7 +490,12 @@ func (reconciler *CloudStackMachineReconciler) SetupWithManager(ctx context.Cont
 					oldMachine := e.ObjectOld.(*clusterv1.Machine)
 					newMachine := e.ObjectNew.(*clusterv1.Machine)
 
-					return oldMachine.Spec.Bootstrap.DataSecretName == nil && newMachine.Spec.Bootstrap.DataSecretName != nil
+					bootstrapBecameAvailable := oldMachine.Spec.Bootstrap.DataSecretName == nil &&
+						newMachine.Spec.Bootstrap.DataSecretName != nil
+					machineBeingDeleted := oldMachine.DeletionTimestamp.IsZero() &&
+						!newMachine.DeletionTimestamp.IsZero()
+
+					return bootstrapBecameAvailable || machineBeingDeleted
 				},
 			}),
 	)

--- a/docs/book/src/topics/cloudstack-permissions.md
+++ b/docs/book/src/topics/cloudstack-permissions.md
@@ -34,6 +34,7 @@ The account that CAPC runs under must minimally be a User type account with a ro
 * listVolumes
 * listZones
 * queryAsyncJobResult
+* removeFromLoadBalancerRule
 * startVirtualMachine
 * stopVirtualMachine
 * updateVMAffinityGroup

--- a/pkg/cloud/isolated_network.go
+++ b/pkg/cloud/isolated_network.go
@@ -35,6 +35,7 @@ type IsoNetworkIface interface {
 	ResolveLoadBalancerRuleDetails(*infrav1.CloudStackIsolatedNetwork) error
 
 	AssignVMToLoadBalancerRule(isoNet *infrav1.CloudStackIsolatedNetwork, instanceID string) error
+	RemoveVMFromLoadBalancerRule(isoNet *infrav1.CloudStackIsolatedNetwork, instanceID string) error
 	DeleteNetwork(infrav1.Network) error
 	DisposeIsoNetResources(*infrav1.CloudStackIsolatedNetwork, *infrav1.CloudStackCluster) error
 }
@@ -463,6 +464,39 @@ func (c *client) AssignVMToLoadBalancerRule(isoNet *infrav1.CloudStackIsolatedNe
 	_, retErr = c.cs.LoadBalancer.AssignToLoadBalancerRule(p)
 	c.customMetrics.EvaluateErrorAndIncrementAcsReconciliationErrorCounter(retErr)
 	return retErr
+}
+
+// RemoveVMFromLoadBalancerRule removes a VM instance from the load balancer rule referenced by
+// isoNet.Status.LBRuleID. The call is idempotent: if the rule is unknown or the VM is not currently
+// a member, it returns nil.
+func (c *client) RemoveVMFromLoadBalancerRule(isoNet *infrav1.CloudStackIsolatedNetwork, instanceID string) error {
+	if isoNet.Status.LBRuleID == "" {
+		return nil
+	}
+
+	lbRuleInstances, err := c.cs.LoadBalancer.ListLoadBalancerRuleInstances(
+		c.cs.LoadBalancer.NewListLoadBalancerRuleInstancesParams(isoNet.Status.LBRuleID))
+	if err != nil {
+		c.customMetrics.EvaluateErrorAndIncrementAcsReconciliationErrorCounter(err)
+		return err
+	}
+
+	found := false
+	for _, instance := range lbRuleInstances.LoadBalancerRuleInstances {
+		if instance.Id == instanceID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+
+	p := c.cs.LoadBalancer.NewRemoveFromLoadBalancerRuleParams(isoNet.Status.LBRuleID)
+	p.SetVirtualmachineids([]string{instanceID})
+	_, err = c.cs.LoadBalancer.RemoveFromLoadBalancerRule(p)
+	c.customMetrics.EvaluateErrorAndIncrementAcsReconciliationErrorCounter(err)
+	return err
 }
 
 // DeleteNetwork deletes an isolated network.

--- a/pkg/cloud/isolated_network_test.go
+++ b/pkg/cloud/isolated_network_test.go
@@ -423,6 +423,66 @@ var _ = ginkgo.Describe("Network", func() {
 		})
 	})
 
+	ginkgo.Context("Remove VM from Load Balancer rule", func() {
+		ginkgo.It("no-op when LBRuleID is empty", func() {
+			dummies.CSISONet1.Status.LBRuleID = ""
+
+			gomega.Ω(client.RemoveVMFromLoadBalancerRule(dummies.CSISONet1, *dummies.CSMachine1.Spec.InstanceID)).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("no-op when VM is not a member of the rule", func() {
+			dummies.CSISONet1.Status.LBRuleID = "lbruleid"
+			lbip := &csapi.ListLoadBalancerRuleInstancesParams{}
+			lbs.EXPECT().NewListLoadBalancerRuleInstancesParams(dummies.CSISONet1.Status.LBRuleID).Return(lbip)
+			lbs.EXPECT().ListLoadBalancerRuleInstances(lbip).Return(&csapi.ListLoadBalancerRuleInstancesResponse{}, nil)
+
+			gomega.Ω(client.RemoveVMFromLoadBalancerRule(dummies.CSISONet1, *dummies.CSMachine1.Spec.InstanceID)).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("removes the VM when it is a member of the rule", func() {
+			dummies.CSISONet1.Status.LBRuleID = "lbruleid"
+			lbip := &csapi.ListLoadBalancerRuleInstancesParams{}
+			rfp := &csapi.RemoveFromLoadBalancerRuleParams{}
+			lbs.EXPECT().NewListLoadBalancerRuleInstancesParams(dummies.CSISONet1.Status.LBRuleID).Return(lbip)
+			lbs.EXPECT().ListLoadBalancerRuleInstances(lbip).Return(&csapi.ListLoadBalancerRuleInstancesResponse{
+				Count: 1,
+				LoadBalancerRuleInstances: []*csapi.VirtualMachine{{
+					Id: *dummies.CSMachine1.Spec.InstanceID,
+				}},
+			}, nil)
+			lbs.EXPECT().NewRemoveFromLoadBalancerRuleParams(dummies.CSISONet1.Status.LBRuleID).Return(rfp)
+			lbs.EXPECT().RemoveFromLoadBalancerRule(rfp).Return(&csapi.RemoveFromLoadBalancerRuleResponse{}, nil)
+
+			gomega.Ω(client.RemoveVMFromLoadBalancerRule(dummies.CSISONet1, *dummies.CSMachine1.Spec.InstanceID)).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("returns an error when listing rule instances fails", func() {
+			dummies.CSISONet1.Status.LBRuleID = "lbruleid"
+			lbip := &csapi.ListLoadBalancerRuleInstancesParams{}
+			lbs.EXPECT().NewListLoadBalancerRuleInstancesParams(dummies.CSISONet1.Status.LBRuleID).Return(lbip)
+			lbs.EXPECT().ListLoadBalancerRuleInstances(lbip).Return(nil, fakeError)
+
+			gomega.Ω(client.RemoveVMFromLoadBalancerRule(dummies.CSISONet1, *dummies.CSMachine1.Spec.InstanceID)).ShouldNot(gomega.Succeed())
+		})
+
+		ginkgo.It("returns an error when CloudStack rejects the removal", func() {
+			dummies.CSISONet1.Status.LBRuleID = "lbruleid"
+			lbip := &csapi.ListLoadBalancerRuleInstancesParams{}
+			rfp := &csapi.RemoveFromLoadBalancerRuleParams{}
+			lbs.EXPECT().NewListLoadBalancerRuleInstancesParams(dummies.CSISONet1.Status.LBRuleID).Return(lbip)
+			lbs.EXPECT().ListLoadBalancerRuleInstances(lbip).Return(&csapi.ListLoadBalancerRuleInstancesResponse{
+				Count: 1,
+				LoadBalancerRuleInstances: []*csapi.VirtualMachine{{
+					Id: *dummies.CSMachine1.Spec.InstanceID,
+				}},
+			}, nil)
+			lbs.EXPECT().NewRemoveFromLoadBalancerRuleParams(dummies.CSISONet1.Status.LBRuleID).Return(rfp)
+			lbs.EXPECT().RemoveFromLoadBalancerRule(rfp).Return(nil, fakeError)
+
+			gomega.Ω(client.RemoveVMFromLoadBalancerRule(dummies.CSISONet1, *dummies.CSMachine1.Spec.InstanceID)).ShouldNot(gomega.Succeed())
+		})
+	})
+
 	ginkgo.Context("load balancer rule does not exist", func() {
 		ginkgo.It("calls cloudstack to create a new load balancer rule.", func() {
 			lbs.EXPECT().NewListLoadBalancerRulesParams().Return(&csapi.ListLoadBalancerRulesParams{})


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Currently, when a control plane `CloudStackMachine` is deleted, CAPC only destroys the underlying CloudStack VM - it never detaches the VM from the `Kubernetes_API_Server` load balancer rule. VM removal can take a while, and the CloudStack LB health check only marks the member offline after some delay, so API traffic keeps hitting the about-to-be-expunged kube-apiserver throughout that window. This causes stale members and intermittent control plane reachability issues during scale-down or rolling replace (most visibly during KCP-driven control plane rollouts)

This change mirrors the CAPO (`cluster-api-provider-openstack`) `DeleteLoadBalancerMember` pattern, with one addition: removal is attempted **early** - as soon as the parent CAPI Machine is marked for deletion - instead of only on the `CloudStackMachine` delete path. The late removal is kept as a safety net

### Changes

- **`pkg/cloud/isolated_network.go`** - added `RemoveVMFromLoadBalancerRule` to the `IsoNetworkIface`. Idempotent: returns `nil` when `LBRuleID` is empty or the VM is not currently a member of the rule. Otherwise calls CloudStack `removeFromLoadBalancerRule`

- **`controllers/cloudstackmachine_controller.go`** - two LB-detach stages plus a small helper:
  - `usesAPIServerLB()` - extracted predicate shared by all LB stages: non-routed isolated network + populated `IsoNet` + `InstanceID` set
  - `RemoveFromLBIfMachineDeleting` - new stage in the regular `Reconcile()` pipeline, ordered **before** `AddToLBIfNeeded`. Fires when the parent CAPI Machine has a `DeletionTimestamp`, the machine is a control plane, and `usesAPIServerLB()` is true. Detaches the VM from the LB rule promptly, before KCP starts cordon/drain. `AddToLBIfNeeded` has a matching guard so a deleting Machine never gets re-added in the same loop
  - `RemoveFromLBIfNeeded` - new stage called from `ReconcileDelete` immediately before `DestroyVMInstance`, acting as a safety net for the case where the early step did not run (CSMachine deleted directly, controller downtime, etc.). Two implementation notes:
    - Detects control plane via the `clusterv1.MachineControlPlaneLabel` on the `CloudStackMachine` itself, because on the delete path the common stages skip loading the CAPI parent Machine (`RunIf(... DeletionTimestamp().IsZero() ..., GetParent(...))`).
    - Fetches the `CloudStackIsolatedNetwork` via `GetObjectByName(IsoNetMetaName(...), r.IsoNet)`, since the delete path does not pre-load it (unlike the regular `Reconcile` path)
  - **CAPI Machine watch predicate widened** - the existing `clusterv1.Machine` update predicate only enqueued the owned `CloudStackMachine` when `Bootstrap.DataSecretName` went from `nil` to set. It now also enqueues when `DeletionTimestamp` transitions from zero to non-zero. Without this, the early-removal stage would only run on the next periodic resync (1m default) - too late.

- **`pkg/cloud/isolated_network_test.go`** - 5 new unit tests covering: empty `LBRuleID` no-op, VM not a member no-op, happy-path removal, list error, remove error

- **`pkg/mocks/mock_client.go`** - regenerated via `make generate-mocks` (gitignored; auto-rebuilt by `make test`)

- **`docs/book/src/topics/cloudstack-permissions.md`** - added the required `removeFromLoadBalancerRule` permission

### Behavior matrix

| Trigger | Machine role | FD network | RoutingMode | Result |
|---|---|---|---|---|
| Parent CAPI Machine `DeletionTimestamp` set | Control plane | Isolated | `""` (non-routed) | Early LB detach during regular `Reconcile()`, before drain |
| `CloudStackMachine` deletion (`ReconcileDelete`) | Control plane | Isolated | `""` (non-routed) | Safety-net LB detach, then VM destroyed |
| Either trigger | Control plane | Isolated | non-empty (routed) | No LB call (no LB used) |
| Either trigger | Control plane | Shared / other | - | No LB call |
| Either trigger | Worker | any | - | No LB call |
| Either trigger | Any | `IsoNet` CR already gone / `LBRuleID` empty | - | Cloud-layer no-op (idempotent) |
| Either trigger | Any | VM not a member of the rule | - | Cloud-layer no-op (idempotent) |

The cluster-scoped LB rule itself continues to be cleaned up through `DisposeIsoNetResources` on cluster teardown (unchanged) - only members are removed on machine delete, matching the CAPO model

### Trade-offs / why both stages

The early stage (`RemoveFromLBIfMachineDeleting`) is what actually shortens the bad window during KCP rollouts. The late stage (`RemoveFromLBIfNeeded` in `ReconcileDelete`) is intentionally kept because:
- The controller may have been down when the parent Machine was marked for deletion
- A user can delete the `CloudStackMachine` directly, bypassing the CAPI Machine
- It costs at most one extra `ListLoadBalancerRuleInstances` call (idempotent no-op when already detached)

*Testing performed:*

- `go build ./...` - clean
- `go vet ./controllers/... ./pkg/cloud/...` - clean
- `REPO_ROOT=$(pwd) go run github.com/onsi/ginkgo/v2/ginkgo --label-filter='!integ' ./pkg/cloud` - **137 passed, 0 failed**, 24 integration specs skipped as expected. All 5 new specs green
- Manually verified the regenerated mock surface includes `RemoveVMFromLoadBalancerRule` on `MockClient`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.