### PR TITLE
Fix CI job failures

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -11,13 +11,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.23
+          go-version: "1.23"
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            hack/tools/go.sum
+
       - name: Run go test with coverage
         run: COVER_PROFILE=coverage.txt make test
       - name: Codecov upload
-        uses: codecov/codecov-action@v5.4.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./cover.out

--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,12 @@ managers:
 manager-cloudstack-infrastructure: ## Build manager binary.
 	CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "${LDFLAGS} -extldflags '-static'" -o $(BIN_DIR)/manager .
 
+SETUP_ENVTEST := $(TOOLS_BIN_DIR)/setup-envtest
+
 export K8S_VERSION=1.28.3
-$(KUBECTL) $(API_SERVER) $(ETCD) &:
-	cd $(TOOLS_DIR) && curl --silent -L "https://go.kubebuilder.io/test-tools/${K8S_VERSION}/$(shell go env GOOS)/$(shell go env GOARCH)" --output - | \
-		tar -C ./ --strip-components=1 -zvxf -
+$(KUBECTL) $(API_SERVER) $(ETCD) &: $(SETUP_ENVTEST)
+	$(SETUP_ENVTEST) use $(K8S_VERSION) --bin-dir $(TOOLS_BIN_DIR)
+	ln -sf "$$($(SETUP_ENVTEST) use $(K8S_VERSION) --bin-dir $(TOOLS_BIN_DIR) -p path)"/* "$(TOOLS_BIN_DIR)"/
 
 ##@ Linting
 ## --------------------------------------
@@ -254,7 +256,7 @@ cluster-api/tilt-settings.json: hack/tilt-settings.json cluster-api
 ## Tests
 ## --------------------------------------
 
-export KUBEBUILDER_ASSETS=$(TOOLS_BIN_DIR)
+export KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use $(K8S_VERSION) --bin-dir $(TOOLS_BIN_DIR) -p path)
 DEEPCOPY_GEN_TARGETS_TEST=$(shell find test/fakes -type d -name "fakes" -exec echo {}\/zz_generated.deepcopy.go \;)
 DEEPCOPY_GEN_INPUTS_TEST=$(shell find test/fakes/* -name "*zz_generated*" -prune -o -type f -print)
 .PHONY: generate-deepcopy-test
@@ -315,6 +317,7 @@ run-e2e-smoke:
 clean: ## Cleans up everything.
 	rm -rf $(RELEASE_DIR)
 	rm -rf bin
+	chmod -R u+w $(TOOLS_BIN_DIR)/k8s 2>/dev/null || true
 	rm -rf $(TOOLS_BIN_DIR)
 	rm -rf cluster-api
 	rm -rf test/e2e/data/infrastructure-cloudstack/*/*yaml

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -44,7 +44,7 @@ ifeq ($(OS), windows)
 	MDBOOK_EXTRACT_COMMAND := unzip -d /tmp
 endif
 
-GOLANGCI_LINT_VERSION := v1.60.2
+GOLANGCI_LINT_VERSION := v1.64.8
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(abspath $(BIN_DIR)/$(GOLANGCI_LINT_BIN))
 GOLANGCI_LINT_PKG := github.com/golangci/golangci-lint/cmd/golangci-lint
@@ -84,8 +84,12 @@ $(STATIC_CHECK): $(BIN_DIR) go.mod go.sum # Build staticcheck from tools folder.
 	go build -tags=tools -o $@ honnef.co/go/tools/cmd/staticcheck
 
 GINKGO := $(BIN_DIR)/ginkgo
-$(GINKGO): $(BIN_DIR) go.mod go.sum # Build staticcheck from tools folder.
+$(GINKGO): $(BIN_DIR) go.mod go.sum # Build ginkgo from tools folder.
 	go build -tags=tools -o $@ github.com/onsi/ginkgo/v2/ginkgo
+
+SETUP_ENVTEST := $(BIN_DIR)/setup-envtest
+$(SETUP_ENVTEST): $(BIN_DIR) # Download setup-envtest locally if necessary.
+	test -s $(abspath $(BIN_DIR))/setup-envtest || GOBIN=$(abspath $(BIN_DIR)) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20
 
 ENVSUBST := $(BIN_DIR)/envsubst
 $(ENVSUBST): $(BIN_DIR) go.mod go.sum # Build envsubst from tools folder.


### PR DESCRIPTION
*Description of changes:*
* Upgrade golangci-lint to fix build failures
* Upgrade & pin versions in github actions
* Migrate to setup-envtest
* Enable caching for go in github actions

<details><summary>Details</summary>
<p>
This pull request updates the project's tooling and CI workflows to improve reliability, reproducibility, and developer experience. The main changes include pinning GitHub Actions to specific commit SHAs, updating tool versions, and switching to `setup-envtest` for managing Kubernetes test binaries.

**CI/CD and Tooling Updates:**

* Updated GitHub Actions in `.github/workflows/go-coverage.yml` to use pinned commit SHAs for `actions/checkout`, `actions/setup-go`, and `codecov/codecov-action`, improving workflow security and reproducibility. Also enabled Go module caching for faster builds.
* Upgraded `golangci-lint` version from `v1.60.2` to `v1.64.8` in `hack/tools/Makefile` for improved linting and bug fixes.

**Kubernetes Test Environment Management:**

* Introduced `setup-envtest` as a managed tool in both `Makefile` and `hack/tools/Makefile`, automating the download and use of Kubernetes test binaries (kubectl, apiserver, etcd) for the specified `K8S_VERSION`. This replaces manual download logic with a more robust, versioned approach. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R94-R98) [[2]](diffhunk://#diff-e10dbadfede00dfda2bb17122cea24cb3e922bd6c051d6e801c29856bb6027d8L87-R93)
* Updated the `KUBEBUILDER_ASSETS` export logic to use the path provided by `setup-envtest`, ensuring test assets are correctly located and versioned.

</p>
</details> 


*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->